### PR TITLE
Add a migration process for the EMAIL list field

### DIFF
--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -1138,7 +1138,7 @@ class EE_MCI_Controller
         // If the MC email (MERGE0) field was mapped to a different form input, remove that override.
         $mc_field_to_ee_q_map = $this->mci_event_list_question_fields($EVT_ID);
         if (array_key_exists('EMAIL', $mc_field_to_ee_q_map)) {
-            $mcqe = EEM_Question_Mailchimp_Field::instance()->get_one(
+            $mcqe_deleted = EEM_Question_Mailchimp_Field::instance()->delete(
                 array(
                     array(
                         'EVT_ID'                 => $EVT_ID,
@@ -1146,9 +1146,6 @@ class EE_MCI_Controller
                     ),
                 )
             );
-            if ($mcqe != null) {
-                $mcqe->delete();
-            }
         }
 
         // Remember this event's MailChimp list data has been verified. No need to do it again

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -329,8 +329,8 @@ class EE_MCI_Controller
                                     $notice_msg = sprintf(
                                         __(
                                             'This registration could not be subscribed to a MailChimp List with ID: %1$s. There were errors regarding the following: %2$s. 
-											Any mandatory or multi-choice fields that are in this MailChimp list require to be paired with Event questions (in this case %3$s event) that correspond by type and possibly by having the same answer values. 
-											If you have further problems please contact support.',
+                                            Any mandatory or multi-choice fields that are in this MailChimp list require to be paired with Event questions (in this case %3$s event) that correspond by type and possibly by having the same answer values. 
+                                            If you have further problems please contact support.',
                                             'event_espresso'
                                         ),
                                         $event_list,
@@ -1133,6 +1133,24 @@ class EE_MCI_Controller
                 $new_list_interest->save();
             }
         }
+
+        // Check the list question fields.
+        // If the MC email (MERGE0) field was mapped to a different form input, remove that override.
+        $mc_field_to_ee_q_map = $this->mci_event_list_question_fields($EVT_ID);
+        if (array_key_exists('EMAIL', $mc_field_to_ee_q_map)) {
+            $mcqe = EEM_Question_Mailchimp_Field::instance()->get_one(
+                array(
+                    array(
+                        'EVT_ID'                 => $EVT_ID,
+                        'QMC_mailchimp_field_id' => 'EMAIL',
+                    ),
+                )
+            );
+            if ($mcqe != null) {
+                $mcqe->delete();
+            }
+        }
+
         // Remember this event's MailChimp list data has been verified. No need to do it again
         $event->update_extra_meta(EE_MCI_Controller::UPDATED_TO_API_V3, true);
     }


### PR DESCRIPTION
## Problem this Pull Request solves
Resolves #5 

This PR adds a scenario to deal with the `EMAIL` (`MERGE0`) list field on migrations if it was ever mapped to an alternative email input from the registration form in the previous add-on versions.

(Mike's alternative description)
Fixes "Cannot have different values for 'email_address', 'merge_fields.EMAIL', and 'merge_fields.MERGE0'" error received because an Event Espresso question besides the system email question was mapped to the MailChimp "EMAIL" field. 

This is fixed by removing the erroneous assignment of a non-email Event Espresso system question to MailChimp "EMAIL" field. (This didn't work properly in the EE 2.3 add-on anyway- this assignment was ignored).

## Testing:
* [ ] With version 2.3.5 of this add-on assign a MC list to an event and change the options so that the List Email field corresponds to an "alternative" email registration form field.
* [ ] Update the add-on to the latest version (2.4+) and try registering for that event. It will fail to subscribe the attendee to the MC list that had the EMAIL field overridden and you will see an error in the API call logs.


## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
