### PR TITLE
Check we have an EE_Attendee object before we try to use it.

### DIFF
--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -231,7 +231,7 @@ class EE_MCI_Controller
                         // Pull the EE_Attendee object for the registration
                         $attendee = $registration->attendee();
                         // If no EE_Attendee object, skip the subcribe call to MailChimp.
-                        if(! $attendee instanceof EE_Attendee) {
+                        if (! $attendee instanceof EE_Attendee) {
                             continue;
                         }
                         $att_email = $attendee->email();

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -228,10 +228,13 @@ class EE_MCI_Controller
                                 $reg_approved = true;
                             }
                         }
-
+                        // Pull the EE_Attendee object for the registration
                         $attendee = $registration->attendee();
-                        $att_email = $attendee->email();
-                        if (($attendee instanceof EE_Attendee) && ! in_array(
+                        // If no EE_Attendee object, skip the subcribe call to MailChimp.
+                        if(! $attendee instanceof EE_Attendee) {
+                            continue;
+                        }
+                        if (! in_array(
                             $att_email,
                             $registered_attendees
                         ) && (! $need_reg_status || $need_reg_status && $reg_approved)) {

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -234,6 +234,7 @@ class EE_MCI_Controller
                         if(! $attendee instanceof EE_Attendee) {
                             continue;
                         }
+                        $att_email = $attendee->email();
                         if (! in_array(
                             $att_email,
                             $registered_attendees


### PR DESCRIPTION
See #3

moved from Codebase 11413, where Tony wrote:

Reported here: https://eventespresso.com/topic/new-email-bug/#post-264933

`$attendee = $registration->attendee();
$att_email = $attendee->email();

if ( ( $attendee instanceof EE_Attendee ) `

So we should be checking attendee is an EE_Attendee before the email() call, granted at that point in the code if you DON'T have an attendee you've got bigger problems but lets prevent the fatal.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
