### PR TITLE
Duplicate MailChimp settings when an event is duplicated.

### DIFF
--- a/EED_Mailchimp.module.php
+++ b/EED_Mailchimp.module.php
@@ -47,6 +47,7 @@ class EED_Mailchimp extends EED_Module
 // 'MailChimp List' option
         add_action('add_meta_boxes', array('EED_Mailchimp', 'espresso_mailchimp_list_metabox'));
         add_action('save_post', array('EED_Mailchimp', 'espresso_mailchimp_save_event'));
+        add_action('AHEE__Extend_Events_Admin_Page___duplicate_event__after', array('EED_Mailchimp', 'espresso_mailchimp_duplicate_event'), 10, 2);
 // Ajax for MailChimp groups refresh
         add_action('wp_ajax_espresso_mailchimp_update_groups', array('EED_Mailchimp', 'espresso_mailchimp_update_groups'));
 // Ajax for MailChimp list fields refresh

--- a/EED_Mailchimp.module.php
+++ b/EED_Mailchimp.module.php
@@ -245,11 +245,11 @@ class EED_Mailchimp extends EED_Module
     {
         // Pull the original event's MailChimp relationships
         $mci_controller = new EE_MCI_Controller();
-        $mci_event_subscriptions = $mci_controller->mci_event_subscriptions( $orig_event->ID() );
+        $mci_event_subscriptions = $mci_controller->mci_event_subscriptions($orig_event->ID());
         // Check if the original event is linked to a list
-        if(!empty($mci_event_subscriptions['list'])){
+        if (!empty($mci_event_subscriptions['list'])) {
             // Event is linked to a list, duplicate the mailchimp selected groups.
-            foreach($mci_event_subscriptions['groups'] as $group) {
+            foreach ($mci_event_subscriptions['groups'] as $group) {
                 $dupe_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
                     array(
                         'EVT_ID'                 => $new_event->ID(),
@@ -260,7 +260,7 @@ class EED_Mailchimp extends EED_Module
                 $dupe_list_interest->save();
             }
             // Duplicate the mailchimp and event question relationships.
-            foreach($mci_event_subscriptions['qfields'] as $mailchimp_question => $event_question_id) {
+            foreach ($mci_event_subscriptions['qfields'] as $mailchimp_question => $event_question_id) {
                 $dupe_qfield = EE_Question_Mailchimp_Field::new_instance(
                     array(
                         'EVT_ID'                 => $new_event->ID(),

--- a/EED_Mailchimp.module.php
+++ b/EED_Mailchimp.module.php
@@ -248,16 +248,27 @@ class EED_Mailchimp extends EED_Module
         $mci_event_subscriptions = $mci_controller->mci_event_subscriptions($orig_event->ID());
         // Check if the original event is linked to a list
         if (!empty($mci_event_subscriptions['list'])) {
-            // Event is linked to a list, duplicate the mailchimp selected groups.
-            foreach ($mci_event_subscriptions['groups'] as $group) {
-                $dupe_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
+            if (!empty($mci_event_subscriptions['groups'])) {
+                // Event is linked to a list, duplicate the mailchimp selected groups.
+                foreach ($mci_event_subscriptions['groups'] as $group) {
+                    $dupe_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
+                        array(
+                            'EVT_ID'                 => $new_event->ID(),
+                            'AMC_mailchimp_list_id'  => $mci_event_subscriptions['list'],
+                            'AMC_mailchimp_group_id' => $group,
+                        )
+                    );
+                    $dupe_list_interest->save();
+                }
+            } else {
+                $dupe_list_group = EE_Event_Mailchimp_List_Group::new_instance(
                     array(
                         'EVT_ID'                 => $new_event->ID(),
                         'AMC_mailchimp_list_id'  => $mci_event_subscriptions['list'],
-                        'AMC_mailchimp_group_id' => $group,
+                        'AMC_mailchimp_group_id' => -1,
                     )
                 );
-                $dupe_list_interest->save();
+                $dupe_list_group->save();
             }
             // Duplicate the mailchimp and event question relationships.
             foreach ($mci_event_subscriptions['qfields'] as $mailchimp_question => $event_question_id) {


### PR DESCRIPTION
If you duplicate an event it's likely you'll want either the same or similar MailChimp settings for that dupe event, this pull request duplicates the settings to the new event.

## How has this been tested
Use the above branch, set up an event with a MailChimp list, some groups and set some question relationships.

Duplicate the event and confirm the MC settings on the dupe match the original events settings.

Register onto the dupe and confirm you are subscribed to the same list with the correct groups and merge vars (questions).

Duplicate an event that does NOT have a MailChimp list set and confirm no errors.

Duplicate an event that has a MailChimp list set but no groups.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
