### PR TITLE
Remove legacy init class & the error-prone version check

### DIFF
--- a/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
+++ b/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
@@ -4,44 +4,6 @@
 *
 **/
 
-// Different methods for EE4.3 and EE4.4.
-if ('4.4.0' > EVENT_ESPRESSO_VERSION) {
-
-    class Mailchimp_Admin_Page_Init extends EE_Admin_Page_Init
-    {
-
-        public function __construct()
-        {
-            do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-            define('EE_MAILCHIMP_LABEL', __('Mailchimp', 'event_espresso'));
-            define('EE_MAILCHIMP_ADMIN_URL', admin_url('admin.php?page=' . ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG));
-            define('EE_MAILCHIMP_TEMPLATE_PATH', ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp/templates/');
-            parent::__construct();
-            $this->_folder_path = ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS;
-        }
-
-        protected function _set_init_properties()
-        {
-            $this->label = EE_MAILCHIMP_LABEL;
-            $this->menu_label = EE_MAILCHIMP_LABEL;
-            $this->menu_slug = ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG;
-            $this->capability = 'manage_options';
-        }
-
-        public function get_menu_map()
-        {
-            $map = array(
-            'group' => 'settings',
-            'menu_order' => 40,
-            'show_on_menu' => true,
-            'parent_slug' => 'espresso_events'
-            );
-            return $map;
-        }
-    }
-
-} else {
-
     class Mailchimp_Admin_Page_Init extends EE_Admin_Page_Init
     {
 
@@ -74,5 +36,3 @@ if ('4.4.0' > EVENT_ESPRESSO_VERSION) {
             ));
         }
     }
-
-}

--- a/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
+++ b/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
@@ -4,35 +4,35 @@
 *
 **/
 
-    class Mailchimp_Admin_Page_Init extends EE_Admin_Page_Init
+class Mailchimp_Admin_Page_Init extends EE_Admin_Page_Init
+{
+
+    public function __construct()
     {
-
-        public function __construct()
-        {
-            do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-            define('EE_MAILCHIMP_LABEL', __('Mailchimp', 'event_espresso'));
-            define('EE_MAILCHIMP_ADMIN_URL', admin_url('admin.php?page=' . ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG));
-            define('EE_MAILCHIMP_TEMPLATE_PATH', ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp/templates/');
-            parent::__construct();
-            $this->_folder_path = ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS;
-        }
-
-        protected function _set_init_properties()
-        {
-            $this->label = EE_MAILCHIMP_LABEL;
-        }
-
-        protected function _set_menu_map()
-        {
-            $this->_menu_map = new EE_Admin_Page_Sub_Menu(array(
-            'menu_group' => 'addons',
-            'menu_order' => 10,
-            'show_on_menu' => true,
-            'parent_slug' => 'espresso_events',
-            'menu_slug' => ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG,
-            'menu_label' => EE_MAILCHIMP_LABEL,
-            'capability' => 'manage_options',
-            'admin_init_page' => $this
-            ));
-        }
+        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
+        define('EE_MAILCHIMP_LABEL', __('Mailchimp', 'event_espresso'));
+        define('EE_MAILCHIMP_ADMIN_URL', admin_url('admin.php?page=' . ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG));
+        define('EE_MAILCHIMP_TEMPLATE_PATH', ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp/templates/');
+        parent::__construct();
+        $this->_folder_path = ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS;
     }
+
+    protected function _set_init_properties()
+    {
+        $this->label = EE_MAILCHIMP_LABEL;
+    }
+
+    protected function _set_menu_map()
+    {
+        $this->_menu_map = new EE_Admin_Page_Sub_Menu(array(
+        'menu_group' => 'addons',
+        'menu_order' => 10,
+        'show_on_menu' => true,
+        'parent_slug' => 'espresso_events',
+        'menu_slug' => ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG,
+        'menu_label' => EE_MAILCHIMP_LABEL,
+        'capability' => 'manage_options',
+        'admin_init_page' => $this
+        ));
+    }
+}


### PR DESCRIPTION
See related core issue that was closed:

https://github.com/eventespresso/event-espresso-core/issues/1421


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)

To test, activate the MailChimp add-on with a site that has Event Espresso 4.10.0 (current master). The settings page should display in the menu and render as expected.
