### PR TITLE
Show MailChimp required fields with an asterix but with no validation

### DIFF
--- a/includes/forms/EE_MC_Merge_Fields_Form.form.php
+++ b/includes/forms/EE_MC_Merge_Fields_Form.form.php
@@ -174,11 +174,10 @@ class EE_MC_Merge_Fields_Form extends EE_Form_Section_Proper
                 $fields_list,
                 array(
                     'default'         => $selected,
-                    'html_label_text' => $l_field['name'],
+                    'html_label_text' => $l_field['required'] ? $l_field['name'] . '*' : $l_field['name'],
                     'html_id'         => 'event-question-' . base64_encode($l_field['name']),
                     'html_name'       => base64_encode($l_field['tag']),
                     'html_class'      => 'ee_event_fields_selects',
-                    'required'        => $l_field['required'],
                 )
             );
 


### PR DESCRIPTION
Set MailChimp required fields to have an * on the field name, but with no actual validation of a value.

See: https://eventespresso.com/topic/text-editor-not-working-when-edit-events/

This is probably just a temp fix to get an update pushed.

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
If you have an MC field set as required you'll get a JS error in the event editor.

## How has this been tested
Set a merge field as required within MailChimp, then set that list to an event in EE and check no JS errors are thrown.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
