### PR TITLE
When adding a subscriber, only send the selected interest for the eve…

### DIFF
--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -395,22 +395,18 @@ class EE_MCI_Controller
      */
     protected function _process_event_group_subscribe_args($event_group = '', $subscribe_args = array())
     {
-        $grouping = explode('-', $event_group);
-        // Is this interest selected.
-        $selected = false;
-        if (isset($grouping[3]) && $grouping[3] === 'true') {
-            $selected = true;
-        }
+        // Initialise the interests array if it hasn't been already.
         if (! isset($subscribe_args['interests']) || empty($subscribe_args['interests'])) {
             $subscribe_args['interests'] = array();
-            $subscribe_args['interests'][ $grouping[0] ] = $selected;
-        } else {
-            foreach ($subscribe_args['interests'] as $interest => $value) {
-                if ($interest != $grouping[0]) {
-                    $subscribe_args['interests'][ $grouping[0] ] = $selected;
-                }
-            }
         }
+
+        $grouping = explode('-', $event_group);
+        
+        // Add selected interests to the subscribe_args.
+        if (isset($grouping[3]) && $grouping[3] === 'true') {
+            $subscribe_args['interests'][ $grouping[0] ] = true;
+        }
+        
         return $subscribe_args;
     }
 


### PR DESCRIPTION
…nts in question as including interests that are not selected and setting them to false removes those interests from the subscriber.

## Problem this Pull Request solves
We currently include all event interests in the subscribe call, like so:

```
Array
(
    [email_address] => tony@example.com
    [interests] => Array
        (
            [e3225beff4] => 
            [69e6badb22] => 
            [b13033b70f] => 
            [16cd340d50] => 
            [d4e0d84388] => 
            [3d068ce158] => 
            [4b825e15aa] => 
            [f6c0918909] => 
            [85fb0100f6] => 
            [786ec8eeb6] => 
            [955a1652e4] => 
            [1c439ca57a] => 
            [cb5f5163b2] => 1
            [34365a4c15] => 1
            [f8a8328620] => 
            [21a20c693d] => 
            [6547afcba0] => 
            [8ddde40b54] => 
            [ae6e54c412] => 
            [0d9841199a] => 
            [23ee7076f6] => 
        )
    [merge_vars] => Array
        (
            [FNAME] => Tony
            [LNAME] => Warwick
        )

)
```

The problem within doing this is it replaces the subscribers currently groups, with the above.

So if you use Event A and Event B on the same list using different groups, whenever you register onto either event, that current events selection completely replaces the others.

## How has this been tested
Create Event A and select a list with groups.
Set at least one group/interest on that event.

Create Event B and set it to the **same** list.
Set it to use another group/interest (it can be in the same 'group' or another)

Register onto Event A and look at your MailChimp audience, not the subscriber has Event A's group set on it.

Register onto Event B with the same details you used for Event A and check your audience again, you'll see the subscriber now only has Event B's group selected.

Now switch to this branch re-register onto Event A again, check your subscriber and you'll see it now has BOTH groups set on it.

Test this with additional groups if preferred but the short of it is that subscribing to an event should not remove groups, only add any additional groups.

Test registering onto an event with no groups for that same List and confirm the contact still has the groups they previously had.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
