### PR TITLE
Fix fatal error on migration from api key check

### DIFF
--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
@@ -48,9 +48,9 @@ class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
                 $config->api_settings->mc_active = true;
                 EE_Config::instance()->update_config('addons', 'EE_Mailchimp', $config);
             }
-            if ($this->count_records_migrated() + $items_actually_migrated >= $this->_count_records_to_migrate()) {
-                $this->set_completed();
-            }
+        }
+        if ($this->count_records_migrated() + $items_actually_migrated >= $this->_count_records_to_migrate()) {
+            $this->set_completed();
         }
         return $items_actually_migrated;
     }

--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
@@ -41,7 +41,7 @@ class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
             $this->add_error(EE_Error::get_notices());
         }
         // Activate MC if the API Key is valid.
-        if (isset($config->api_settings->api_key) && $config->api_settings->api_key != '') {
+        if (isset($config->api_settings->api_key) && $config->api_settings->api_key) {
             $mci_controller = new EE_MCI_Controller();
             $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
             if ($key_ok) {

--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
@@ -41,14 +41,16 @@ class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
             $this->add_error(EE_Error::get_notices());
         }
         // Activate MC if the API Key is valid.
-        $mci_controller = new EE_MCI_Controller();
-        $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
-        if ($key_ok) {
-            $config->api_settings->mc_active = true;
-            EE_Config::instance()->update_config('addons', 'EE_Mailchimp', $config);
-        }
-        if ($this->count_records_migrated() + $items_actually_migrated >= $this->_count_records_to_migrate()) {
-            $this->set_completed();
+        if (isset($config->api_settings->api_key) && $config->api_settings->api_key != '') {
+            $mci_controller = new EE_MCI_Controller();
+            $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
+            if ($key_ok) {
+                $config->api_settings->mc_active = true;
+                EE_Config::instance()->update_config('addons', 'EE_Mailchimp', $config);
+            }
+            if ($this->count_records_migrated() + $items_actually_migrated >= $this->_count_records_to_migrate()) {
+                $this->set_completed();
+            }
         }
         return $items_actually_migrated;
     }

--- a/db/migration_scripts/2_3_0_stages/EE_DMS_2_3_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_3_0_stages/EE_DMS_2_3_0_mc_options.dmsstage.php
@@ -33,7 +33,7 @@ class EE_DMS_2_3_0_mc_options extends EE_Data_Migration_Script_Stage
         $items_actually_migrated++;
 
         // Activate MC if the API Key is valid.
-        if (isset($config->api_settings->api_key) && $config->api_settings->api_key != '') {
+        if (isset($config->api_settings->api_key) && $config->api_settings->api_key) {
             $mci_controller = new EE_MCI_Controller();
             $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
             if ($key_ok) {

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -1181,11 +1181,15 @@ class EE_MCI_Controller
             $error['body'] = '';
         }
         $this->mcapi_error = apply_filters('FHEE__EE_MCI_Controller__mci_throw_error__mcapi_error', $error);
-        EEM_Change_Log::instance()->log(
-            EED_Mailchimp::log_type,
-            $error,
-            null
-        );
+
+        // Only save a log entry if not in maintenance mode
+        if (EE_Maintenance_Mode::instance()->models_can_query()) {
+            EEM_Change_Log::instance()->log(
+                EED_Mailchimp::log_type,
+                $error,
+                null
+            );
+        }
     }
 
 


### PR DESCRIPTION
See: https://secure.helpscout.net/conversation/1082148765/744136?folderId=100574

Currently, when the site is in maintenance mode to run the MailChimp migration, after the first MC migration stage it will check if the API key is valid.

If we don't have an API key set it checks anyway, causing an error which then tries to write a log entry.

In MM2 that fails with:

> Event Espresso Level 2 Maintenance mode is active. That means EE can not run ANY database queries until the necessary migration scripts have run which will take EE out of maintenance mode level 2. Please inform support of this error.

This change simply checks if we have a value set for the API before checking if it's a valid key and also wraps the log entry in a `model_can_query()` check so it will only add a log entry when not in maintenance mode.

## How has this been tested
Set up an EE3 site with the MailChimp add-on.
(Set up at least 1 event with mailchimp settings)
Remove the API key from your EE3 site.

Installed EE4 and the EE4 MailChimp add-on.
Check the migration kicks in and does not throw a fatal after the first stage.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
