### PR TITLE
Only try to migrate rows where the mailchimp list ID is not NULL

### DIFF
--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_list_group.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_list_group.dmsstage.php
@@ -25,6 +25,7 @@ class EE_DMS_2_0_0_mc_list_group extends EE_Data_Migration_Script_Stage_Table
         $this->_pretty_name = __("Mailchimp List Group", "event_espresso");
         $this->_old_table = $wpdb->prefix . "events_mailchimp_event_rel";
         $this->_new_table = $wpdb->prefix . "esp_event_mailchimp_list_group";
+        $this->_extra_where_sql = "WHERE mailchimp_list_id IS NOT NULL OR  mailchimp_list_id != ''";
         parent::__construct();
     }
 


### PR DESCRIPTION
Right now the MailChimp add-on pulls all EE3 mailchimp rows and throws a notice if there is no mailchimp list id set on the row or theres no new EE4 event to replace the row (meaning there can be a LOT of notices for rows that simply don't apply). This changes the migration query to only pull rows where the Mailchimp list ID is NOT NULL or empty.

The nice part of this (although to be honest, it doesn't matter) is that if a user updated the event to note use a MailChimp list, but had groups set on that event, those groups still migrate over as `mailchimp_list_id` is set to 0 in that case.

## How has this been tested
Set up an EE3 site and have some events that have MailChimp enabled on them and some that don't.

You can test setting a list **and** a group, saving and then setting the event not to use a list just to confirm if preferred.

If possible (if not using a fresh site this may be impractical) make a note of how many events **do** have MailChimp records, if you have say 10 events and 4 of them are set to use MailChimp in someway then when migrations run, you should get a count of 4 records, not 10 like master would.

You shouldn't get any notices stating that mailchimp_list_id can not be NULL during the migration.

When migrations are complete confirm that the events have the lists assigned to them etc.

## Checklist
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
