### PR TITLE
Use array_filter() to remove any null values from merge vars.

### DIFF
--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -250,7 +250,8 @@ class EE_MCI_Controller
                                 $EVT_ID
                             );
                             // Old version used 'merge_vars' but API v3 calls them 'merge_fields'
-                            $subscribe_args['merge_fields'] = array_filter($subscribe_args['merge_vars']);
+                            // Remove any merge_vars with a null value as the API rejects them.
+                            $subscribe_args['merge_fields'] = array_filter($subscribe_args['merge_vars'], function($merge_var) { return !is_null($merge_var); });
                             unset($subscribe_args['merge_vars']);
 
                             // Verify merge_fields and interests aren't empty, and if they are they need to be stdClasses so that they become JSON objects still

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -250,7 +250,7 @@ class EE_MCI_Controller
                                 $EVT_ID
                             );
                             // Old version used 'merge_vars' but API v3 calls them 'merge_fields'
-                            $subscribe_args['merge_fields'] = $subscribe_args['merge_vars'];
+                            $subscribe_args['merge_fields'] = array_filter($subscribe_args['merge_vars']);
                             unset($subscribe_args['merge_vars']);
 
                             // Verify merge_fields and interests aren't empty, and if they are they need to be stdClasses so that they become JSON objects still
@@ -291,8 +291,15 @@ class EE_MCI_Controller
                                     ),
                                     $subscribe_args
                                 );
-                                // Log error.
-                                if (! $this->MailChimp->success()) {
+                                if ($this->MailChimp->success()) {
+                                    do_action(
+                                        'FHEE__EE_MCI_Controller__mci_submit_to_mailchimp__success',
+                                        $registration,
+                                        $att_email,
+                                        $this->MailChimp,
+                                        $subscribe_args
+                                    );
+                                } else {
                                     $this->set_error($put_member);
                                     $errors = '';
                                     if (isset($put_member['errors']) && is_array($put_member['errors'])) {


### PR DESCRIPTION
See here: https://eventespresso.com/topic/ee-mailchimp-integration/

I couldn't reproduce the problem but when searching I found a few reports of the same error reported if you the value is null for any of the merge vars so figured we may as well fix it.

I gave the user that reported this a slight different snippet using a hook on the subscribe_args:

https://gist.github.com/Pebblo/a53a6f50782b2eb0312f2efae7a8401c

This fix leaves falsey values in case people want to send 0 values etc.

## How has this been tested
Just confirm that MailChimp subscriptions still work on your events, it doesn't matter which options you use for 'when' the subscription happens within EE just that it does indeed still work.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
