### PR TITLE
Code Cleanup

### DIFF
--- a/EED_Mailchimp.module.php
+++ b/EED_Mailchimp.module.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class  EED_Mailchimp
  *
@@ -9,66 +10,99 @@ class EED_Mailchimp extends EED_Module
 {
 
 
-
     /**
      * Constant used in EEM_Change_Log for the value of LOG_type for mailchimp logs
      */
     const log_type = 'mailchimp';
 
+
     /**
-     * @return EED_Mailchimp
+     * @return EED_Mailchimp|EED_Module
      */
     public static function instance()
     {
         return parent::get_instance(__CLASS__);
     }
 
+
     /**
      * For hooking into EE Core, other modules, etc.
      *
      * @access public
      * @return void
+     * @throws EE_Error
      */
     public static function set_hooks()
     {
         EED_Mailchimp::set_eemc_hooks();
     }
 
+
     /**
      * For hooking into EE Admin Core and other modules, etc.
      *
      * @access public
      * @return void
+     * @throws EE_Error
      */
     public static function set_hooks_admin()
     {
         EED_Mailchimp::set_eemc_hooks();
-        add_action('admin_enqueue_scripts', array( 'EED_Mailchimp', 'mailchimp_link_scripts_styles' ));
-// 'MailChimp List' option
-        add_action('add_meta_boxes', array('EED_Mailchimp', 'espresso_mailchimp_list_metabox'));
-        add_action('save_post', array('EED_Mailchimp', 'espresso_mailchimp_save_event'));
-        add_action('AHEE__Extend_Events_Admin_Page___duplicate_event__after', array('EED_Mailchimp', 'espresso_mailchimp_duplicate_event'), 10, 2);
-// Ajax for MailChimp groups refresh
-        add_action('wp_ajax_espresso_mailchimp_update_groups', array('EED_Mailchimp', 'espresso_mailchimp_update_groups'));
-// Ajax for MailChimp list fields refresh
-        add_action('wp_ajax_espresso_mailchimp_update_list_fields', array('EED_Mailchimp', 'espresso_mailchimp_update_list_fields'));
+        add_action('admin_enqueue_scripts', ['EED_Mailchimp', 'mailchimp_link_scripts_styles']);
+        // 'MailChimp List' option
+        add_action('add_meta_boxes', ['EED_Mailchimp', 'espresso_mailchimp_list_metabox']);
+        add_action('save_post', ['EED_Mailchimp', 'espresso_mailchimp_save_event']);
+        add_action(
+            'AHEE__Extend_Events_Admin_Page___duplicate_event__after',
+            ['EED_Mailchimp', 'espresso_mailchimp_duplicate_event'],
+            10,
+            2
+        );
+        // Ajax for MailChimp groups refresh
+        add_action('wp_ajax_espresso_mailchimp_update_groups', ['EED_Mailchimp', 'espresso_mailchimp_update_groups']);
+        // Ajax for MailChimp list fields refresh
+        add_action(
+            'wp_ajax_espresso_mailchimp_update_list_fields',
+            ['EED_Mailchimp', 'espresso_mailchimp_update_list_fields']
+        );
     }
 
 
+    /**
+     * @throws EE_Error
+     */
     public static function set_eemc_hooks()
     {
         // Set defaults.
         $mc_config = EED_Mailchimp::setup_mc_defaults();
-// Hook into the EE _process_attendee_information.
+        // Hook into the EE _process_attendee_information.
         if ($mc_config->api_settings->submit_to_mc_when == 'attendee-information-end') {
-            add_action('AHEE__EE_Single_Page_Checkout__process_attendee_information__end', array('EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'), 10, 2);
-            remove_action('AHEE__EE_SPCO_Reg_Step_Finalize_Registration__process_reg_step__completed', array('EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'));
-        } elseif ($mc_config->api_settings->submit_to_mc_when == 'reg-step-completed' || $mc_config->api_settings->submit_to_mc_when == 'reg-step-approved') {
-            add_action('AHEE__EE_SPCO_Reg_Step_Finalize_Registration__process_reg_step__completed', array('EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'), 10, 2);
-            remove_action('AHEE__EE_Single_Page_Checkout__process_attendee_information__end', array('EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'));
+            add_action(
+                'AHEE__EE_Single_Page_Checkout__process_attendee_information__end',
+                ['EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'],
+                10,
+                2
+            );
+            remove_action(
+                'AHEE__EE_SPCO_Reg_Step_Finalize_Registration__process_reg_step__completed',
+                ['EED_Mailchimp', 'espresso_mailchimp_submit_to_mc']
+            );
+        } elseif ($mc_config->api_settings->submit_to_mc_when == 'reg-step-completed'
+                  || $mc_config->api_settings->submit_to_mc_when == 'reg-step-approved'
+        ) {
+            add_action(
+                'AHEE__EE_SPCO_Reg_Step_Finalize_Registration__process_reg_step__completed',
+                ['EED_Mailchimp', 'espresso_mailchimp_submit_to_mc'],
+                10,
+                2
+            );
+            remove_action(
+                'AHEE__EE_Single_Page_Checkout__process_attendee_information__end',
+                ['EED_Mailchimp', 'espresso_mailchimp_submit_to_mc']
+            );
         }
         // add a different log type
-        add_filter('FHEE__EE_Enum_Text_Field___allowed_enum_options', array( 'EED_Mailchimp', 'add_log_type' ), 10, 2);
+        add_filter('FHEE__EE_Enum_Text_Field___allowed_enum_options', ['EED_Mailchimp', 'add_log_type'], 10, 2);
     }
 
 
@@ -76,17 +110,19 @@ class EED_Mailchimp extends EED_Module
      *    Setup defaults.
      *
      * @return EE_Mailchimp_Config
+     * @throws EE_Error
      */
     public static function setup_mc_defaults()
     {
         $mc_config = EED_Mailchimp::get_config();
-        if (! isset($mc_config->api_settings->submit_to_mc_when) || empty($mc_config->api_settings->submit_to_mc_when)) {
+        if (! isset($mc_config->api_settings->submit_to_mc_when)
+            || empty($mc_config->api_settings->submit_to_mc_when)
+        ) {
             $mc_config->api_settings->submit_to_mc_when = 'reg-step-approved';
             EED_Mailchimp::update_config($mc_config);
         }
         return $mc_config;
     }
-
 
 
     /**
@@ -102,13 +138,6 @@ class EED_Mailchimp extends EED_Module
         return EED_Mailchimp::instance()->config();
     }
 
-
-
-    /**
-     *    _set_config
-     *
-     * @return EE_Mailchimp_Config
-     */
     public static function set_config()
     {
         EED_Mailchimp::instance()->set_config_section('addons');
@@ -117,13 +146,12 @@ class EED_Mailchimp extends EED_Module
     }
 
 
-
     /**
      * update_config
      *
-     * @param \EE_Mailchimp_Config $config
-     * @return \EE_Mailchimp_Config
-     * @throws \EE_Error
+     * @param EE_Mailchimp_Config $config
+     * @return EE_Mailchimp_Config
+     * @throws EE_Error
      */
     public static function update_config(EE_Mailchimp_Config $config)
     {
@@ -131,11 +159,10 @@ class EED_Mailchimp extends EED_Module
     }
 
 
-
     /**
      *    config
      *
-     * @return EE_Mailchimp_Config
+     * @return EE_Config_Base|EE_Mailchimp_Config
      */
     public function config()
     {
@@ -144,17 +171,17 @@ class EED_Mailchimp extends EED_Module
     }
 
 
-
     /**
      * Run initial module setup.
      *
      * @access public
-     * @param WP  $WP
+     * @param WP $WP
      * @return void
      */
     public function run($WP)
     {
     }
+
 
     /**
      * Load the MCI scripts and styles.
@@ -164,43 +191,60 @@ class EED_Mailchimp extends EED_Module
      */
     public static function mailchimp_link_scripts_styles()
     {
-        wp_enqueue_style('espresso_mailchimp_gen_styles', ESPRESSO_MAILCHIMP_URL . "assets/css/ee_mailchimp_styles.css", false, ESPRESSO_MAILCHIMP_VERSION);
-        wp_enqueue_script('espresso_mailchimp_base_scripts', ESPRESSO_MAILCHIMP_URL . 'assets/js/ee-mailchimp-base-scripts.js', false, ESPRESSO_MAILCHIMP_VERSION);
+        wp_enqueue_style(
+            'espresso_mailchimp_gen_styles',
+            ESPRESSO_MAILCHIMP_URL . "assets/css/ee_mailchimp_styles.css",
+            false,
+            ESPRESSO_MAILCHIMP_VERSION
+        );
+        wp_enqueue_script(
+            'espresso_mailchimp_base_scripts',
+            ESPRESSO_MAILCHIMP_URL . 'assets/js/ee-mailchimp-base-scripts.js',
+            false,
+            ESPRESSO_MAILCHIMP_VERSION
+        );
         do_action('AHEE__EED_Mailchimp__mailchimp_link_scripts_styles__end');
     }
+
 
     /**
      * An ajax to refresh the list of groups of the MailChimp List selected in the event.
      *
      * @return void
+     * @throws EE_Error
      */
     public static function espresso_mailchimp_update_groups()
     {
         $mci_controller = new EE_MCI_Controller();
-        $mci_data = $_POST['mci_data'];
+        $mci_data       = $_POST['mci_data'];
         echo $mci_controller->mci_list_mailchimp_groups($mci_data['event_id'], $mci_data['list_id']);
         exit;
     }
+
 
     /**
      * An ajax to refresh the  selected MailChimp List's merge fields.
      *
      * @return void
+     * @throws EE_Error
      */
     public static function espresso_mailchimp_update_list_fields()
     {
         $mci_controller = new EE_MCI_Controller();
-        $mci_data = $_POST['mci_data'];
+        $mci_data       = $_POST['mci_data'];
         echo $mci_controller->mci_list_mailchimp_fields($mci_data['event_id'], $mci_data['list_id']);
         exit;
     }
 
+
     /**
      * Submit new attendee information to MailChimp (if any MailChimp list to submit to selected for the current event).
      *
-     * @param EED_Single_Page_Checkout $spc_obj  Single Page Checkout (SPCO) Object.
-     * @param array/EE_Payment $spc_data  Valid data from the Attendee Information Registration form / EE_Payment.
+     * @param EED_Single_Page_Checkout $spc_obj Single Page Checkout (SPCO) Object.
+     * @param                          $spc_data
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function espresso_mailchimp_submit_to_mc($spc_obj, $spc_data)
     {
@@ -211,17 +255,24 @@ class EED_Mailchimp extends EED_Module
         }
     }
 
+
     /**
      * Save the meta when the post is saved.
      *
      * @param int $event_id The ID of the event being saved.
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function espresso_mailchimp_save_event($event_id)
     {
         // Nonce checks.
-        $is_ok = EED_Mailchimp::espresso_mailchimp_authorization_checks('espresso_mailchimp_list_box', 'espresso_mailchimp_list_box_nonce');
-// Auto-save? ...do nothing.
+        $is_ok =
+            EED_Mailchimp::espresso_mailchimp_authorization_checks(
+                'espresso_mailchimp_list_box',
+                'espresso_mailchimp_list_box_nonce'
+            );
+        // Auto-save? ...do nothing.
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
             return $event_id;
         }
@@ -234,93 +285,107 @@ class EED_Mailchimp extends EED_Module
         return $event_id;
     }
 
+
     /**
      * Duplicate the meta when the post is duplicated.
      *
-     * @param EE_Event $new_event The new EE Event object.
+     * @param EE_Event $new_event  The new EE Event object.
      * @param EE_Event $orig_event The original EE Event object.
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function espresso_mailchimp_duplicate_event($new_event, $orig_event)
     {
         // Pull the original event's MailChimp relationships
-        $mci_controller = new EE_MCI_Controller();
+        $mci_controller          = new EE_MCI_Controller();
         $mci_event_subscriptions = $mci_controller->mci_event_subscriptions($orig_event->ID());
         // Check if the original event is linked to a list
-        if (!empty($mci_event_subscriptions['list'])) {
-            if (!empty($mci_event_subscriptions['groups'])) {
+        if (! empty($mci_event_subscriptions['list'])) {
+            if (! empty($mci_event_subscriptions['groups'])) {
                 // Event is linked to a list, duplicate the mailchimp selected groups.
                 foreach ($mci_event_subscriptions['groups'] as $group) {
                     $dupe_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
-                        array(
+                        [
                             'EVT_ID'                 => $new_event->ID(),
                             'AMC_mailchimp_list_id'  => $mci_event_subscriptions['list'],
                             'AMC_mailchimp_group_id' => $group,
-                        )
+                        ]
                     );
                     $dupe_list_interest->save();
                 }
             } else {
                 $dupe_list_group = EE_Event_Mailchimp_List_Group::new_instance(
-                    array(
+                    [
                         'EVT_ID'                 => $new_event->ID(),
                         'AMC_mailchimp_list_id'  => $mci_event_subscriptions['list'],
                         'AMC_mailchimp_group_id' => -1,
-                    )
+                    ]
                 );
                 $dupe_list_group->save();
             }
             // Duplicate the mailchimp and event question relationships.
             foreach ($mci_event_subscriptions['qfields'] as $mailchimp_question => $event_question_id) {
                 $dupe_qfield = EE_Question_Mailchimp_Field::new_instance(
-                    array(
+                    [
                         'EVT_ID'                 => $new_event->ID(),
                         'QST_ID'                 => $event_question_id,
                         'QMC_mailchimp_field_id' => $mailchimp_question,
-                    )
+                    ]
                 );
                 $dupe_qfield->save();
             }
         }
     }
 
+
     /**
      * Add 'MailChimp List' option (metabox) to events admin (add/edit) page (if the API Key is valid).
      *
      * @access public
-     * @param string $post_type  Type of the post.
+     * @param string $post_type Type of the post.
      * @return void
      */
     public static function espresso_mailchimp_list_metabox($post_type)
     {
         $mc_config = EED_Mailchimp::instance()->config();
-// Is MC integration active and is espresso event page.
+        // Is MC integration active and is espresso event page.
         if ($post_type == 'espresso_events' && $mc_config->api_settings->mc_active) {
-            add_meta_box('espresso_mailchimp_list', __('MailChimp List', 'event_espresso'), array( 'EED_Mailchimp', 'espresso_mailchimp_render_box_content' ), $post_type, 'side', 'default');
+            add_meta_box(
+                'espresso_mailchimp_list',
+                __('MailChimp List', 'event_espresso'),
+                ['EED_Mailchimp', 'espresso_mailchimp_render_box_content'],
+                $post_type,
+                'side'
+            );
         }
     }
+
 
     /**
      * Get 'MailChimp List' metabox contents.
      *
      * @access public
-     * @param WP_Post $event  The post object.
+     * @param WP_Post $event The post object.
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public static function espresso_mailchimp_render_box_content($event)
     {
         $mci_controller = new EE_MCI_Controller();
-// Add an nonce field.
+        // Add an nonce field.
         wp_nonce_field('espresso_mailchimp_list_box', 'espresso_mailchimp_list_box_nonce');
         echo $mci_controller->mci_set_metabox_contents($event);
     }
+
 
     /**
      * Do authorization checks on save_post.
      *
      * @access public
-     * @param string $nonce_action  Nonce action.
-     * @param string $nonce_name  Nonce to verify.
+     * @param string $nonce_action Nonce action.
+     * @param string $nonce_name   Nonce to verify.
      * @return bool  Is authorization OK.
      */
     public static function espresso_mailchimp_authorization_checks($nonce_action, $nonce_name)
@@ -330,49 +395,95 @@ class EED_Mailchimp extends EED_Module
             return false;
         }
         $nonce = $_POST[ $nonce_name ];
-// Verify that the nonce is valid.
+        // Verify that the nonce is valid.
         if (! wp_verify_nonce($nonce, $nonce_action)) {
             return false;
         }
         return true;
     }
 
+
+    /**
+     * @param                     $enum_options
+     * @param EE_Model_Field_Base $field_obj
+     * @return mixed
+     * @throws EE_Error
+     */
     public static function add_log_type($enum_options, EE_Model_Field_Base $field_obj)
     {
         if ($field_obj instanceof EE_Enum_Text_Field
-            && $field_obj->get_name() === 'LOG_type') {
+            && $field_obj->get_name() === 'LOG_type'
+        ) {
             $enum_options[ EED_Mailchimp::log_type ] = esc_html__('MailChimp', 'event_espresso');
         }
         return $enum_options;
     }
 
+
     /**
      *  Override other methods
+     *
+     * @param $a
+     * @param $b
+     * @return false
      */
     public function __set($a, $b)
     {
         return false;
     }
+
+
+    /**
+     * @param $a
+     * @return false
+     */
     public function __get($a)
     {
         return false;
     }
+
+
+    /**
+     * @param $a
+     * @return false
+     */
     public function __isset($a)
     {
         return false;
     }
+
+
+    /**
+     * @param $a
+     * @return false
+     */
     public function __unset($a)
     {
         return false;
     }
+
+
+    /**
+     * @return false
+     */
     public function __clone()
     {
         return false;
     }
+
+
+    /**
+     * @return false
+     */
     public function __wakeup()
     {
         return false;
     }
+
+
+    /**
+     * @return false
+     */
     public function __destruct()
     {
         return false;

--- a/EE_MailChimp.class.php
+++ b/EE_MailChimp.class.php
@@ -59,6 +59,8 @@ class EE_MailChimp extends EE_Addon
                 'config_class'     => EE_MailChimp::CONFIG_CLASS,
                 'config_name'      => EE_MailChimp::CONFIG_NAME,
                 'autoloader_paths' => [
+                    'EE_Mailchimp_Config_Api_Settings' => ESPRESSO_MAILCHIMP_DIR
+                                                          . 'EE_Mailchimp_Config_Api_Settings.php',
                     'EE_MCI_Controller'                => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS
                                                           . 'EE_MCI_Controller.class.php',
                     'Mailchimp_Admin_Page'             => ESPRESSO_MAILCHIMP_ADMIN_DIR

--- a/EE_MailChimp.class.php
+++ b/EE_MailChimp.class.php
@@ -1,8 +1,10 @@
 <?php
+
 define('ESPRESSO_MAILCHIMP_URL', plugin_dir_url(ESPRESSO_MAILCHIMP_MAIN_FILE));
-define('ESPRESSO_MAILCHIMP_ADMIN_DIR', ESPRESSO_MAILCHIMP_DIR . 'admin' . DS);
+define('ESPRESSO_MAILCHIMP_ADMIN_DIR', ESPRESSO_MAILCHIMP_DIR . 'admin' . DS . 'mailchimp' . DS);
 define('ESPRESSO_MAILCHIMP_DB_DIR', ESPRESSO_MAILCHIMP_DIR . 'db' . DS);
 define('ESPRESSO_MAILCHIMP_DMS_PATH', ESPRESSO_MAILCHIMP_DB_DIR . 'migration_scripts' . DS);
+define('ESPRESSO_MAILCHIMP_FORMS_PATH', ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS);
 define('ESPRESSO_MAILCHIMP_MODELS_PATH', ESPRESSO_MAILCHIMP_DB_DIR . 'models' . DS);
 define('ESPRESSO_MAILCHIMP_CLASSES_PATH', ESPRESSO_MAILCHIMP_DB_DIR . 'classes' . DS);
 define('ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG', 'mailchimp');
@@ -23,16 +25,16 @@ class EE_MailChimp extends EE_Addon
      *  For registering the activation hook.
      */
     const activation_indicator_option_name = 'ee4_mailchimp_activation';
-/**
+
+    /**
      *  name used to save the config
      */
     const CONFIG_NAME = 'Mailchimp';
-/**
+
+    /**
      *  Class used for storing config
      */
     const CONFIG_CLASS = 'EE_Mailchimp_Config';
-
-
 
 
     /**
@@ -40,44 +42,51 @@ class EE_MailChimp extends EE_Addon
      *
      * @access public
      * @return void
-     * @throws \EE_Error
+     * @throws EE_Error
      */
     public static function register_addon()
     {
-
         // Register our add-on via Plugin API.
-        EE_Register_Addon::register('MailChimp', array(
-                'version'           => ESPRESSO_MAILCHIMP_VERSION,
-                'class_name'        => 'EE_MailChimp',
-                'min_core_version'  => '4.9.26',
-                'main_file_path'    => ESPRESSO_MAILCHIMP_MAIN_FILE,
-                'admin_path'        => ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS,
-                'admin_callback'    => 'additional_mailchimp_admin_hooks',
-                'config_class'      => EE_MailChimp::CONFIG_CLASS,
-                'config_name'       => EE_MailChimp::CONFIG_NAME,
-                'autoloader_paths'  => array(
-                    'EE_MCI_Controller'                  => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'EE_MCI_Controller.class.php',
-                    'Mailchimp_Admin_Page'               => ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS . 'Mailchimp_Admin_Page.core.php',
-                    'Mailchimp_Admin_Page_Init'          => ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS . 'Mailchimp_Admin_Page_Init.core.php',
-                    'EE_Mailchimp_Config'                => ESPRESSO_MAILCHIMP_DIR . 'EE_Mailchimp_Config.php',
-                    'EE_Div_Per_Section_Spaced_Layout'   => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS . 'EE_Div_Per_Section_Spaced_Layout.strategy.php',
-                    'EE_MC_Metabox_Form'             => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS . 'EE_MC_Metabox_Form.form.php',
-                    'EE_MC_Lists_Form'               => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS . 'EE_MC_Lists_Form.form.php',
-                    'EE_MC_Merge_Fields_Form'        => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS . 'EE_MC_Merge_Fields_Form.form.php',
-                    'EE_MC_Interest_Categories_Form' => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS . 'forms' . DS . 'EE_MC_Interest_Categories_Form.form.php'
-                ),
-                'model_paths'           => array(ESPRESSO_MAILCHIMP_MODELS_PATH),
-                'class_paths'           => array(ESPRESSO_MAILCHIMP_CLASSES_PATH),
-                'dms_paths'             => array( ESPRESSO_MAILCHIMP_DMS_PATH ),
-                'module_paths'          => array( ESPRESSO_MAILCHIMP_DIR . 'EED_Mailchimp.module.php' ),
-                'pue_options'           => array(
-                    'pue_plugin_slug'   => 'eea-mailchimp',
-                    'checkPeriod'       => '24',
-                    'use_wp_update'     => false
-                )
-            ));
+        EE_Register_Addon::register(
+            'MailChimp',
+            [
+                'version'          => ESPRESSO_MAILCHIMP_VERSION,
+                'class_name'       => 'EE_MailChimp',
+                'min_core_version' => '4.9.26',
+                'main_file_path'   => ESPRESSO_MAILCHIMP_MAIN_FILE,
+                'admin_path'       => ESPRESSO_MAILCHIMP_ADMIN_DIR,
+                'admin_callback'   => 'additional_mailchimp_admin_hooks',
+                'config_class'     => EE_MailChimp::CONFIG_CLASS,
+                'config_name'      => EE_MailChimp::CONFIG_NAME,
+                'autoloader_paths' => [
+                    'EE_MCI_Controller'                => ESPRESSO_MAILCHIMP_DIR . 'includes' . DS
+                                                          . 'EE_MCI_Controller.class.php',
+                    'Mailchimp_Admin_Page'             => ESPRESSO_MAILCHIMP_ADMIN_DIR
+                                                          . 'Mailchimp_Admin_Page.core.php',
+                    'Mailchimp_Admin_Page_Init'        => ESPRESSO_MAILCHIMP_ADMIN_DIR
+                                                          . 'Mailchimp_Admin_Page_Init.core.php',
+                    'EE_Mailchimp_Config'              => ESPRESSO_MAILCHIMP_DIR . 'EE_Mailchimp_Config.php',
+                    'EE_Div_Per_Section_Spaced_Layout' => ESPRESSO_MAILCHIMP_FORMS_PATH
+                                                          . 'EE_Div_Per_Section_Spaced_Layout.strategy.php',
+                    'EE_MC_Metabox_Form'               => ESPRESSO_MAILCHIMP_FORMS_PATH . 'EE_MC_Metabox_Form.form.php',
+                    'EE_MC_Lists_Form'                 => ESPRESSO_MAILCHIMP_FORMS_PATH . 'EE_MC_Lists_Form.form.php',
+                    'EE_MC_Merge_Fields_Form'          => ESPRESSO_MAILCHIMP_FORMS_PATH
+                                                          . 'EE_MC_Merge_Fields_Form.form.php',
+                    'EE_MC_Interest_Categories_Form'   => ESPRESSO_MAILCHIMP_FORMS_PATH
+                                                          . 'EE_MC_Interest_Categories_Form.form.php',
+                ],
+                'model_paths'      => [ESPRESSO_MAILCHIMP_MODELS_PATH],
+                'class_paths'      => [ESPRESSO_MAILCHIMP_CLASSES_PATH],
+                'dms_paths'        => [ESPRESSO_MAILCHIMP_DMS_PATH],
+                'module_paths'     => [ESPRESSO_MAILCHIMP_DIR . 'EED_Mailchimp.module.php'],
+                'pue_options'      => [
+                    'pue_plugin_slug' => 'eea-mailchimp',
+                    'checkPeriod'     => '24',
+                    'use_wp_update'   => false,
+                ],
+            ]
+        );
     }
-
 
 
     /**
@@ -91,8 +100,6 @@ class EE_MailChimp extends EE_Addon
     }
 
 
-
-
     /**
      *  Additional admin hooks.
      *
@@ -103,33 +110,28 @@ class EE_MailChimp extends EE_Addon
     {
         // Is admin and not in M-Mode ?
         if (is_admin() && ! EE_Maintenance_Mode::instance()->level()) {
-            add_filter('plugin_action_links', array('EE_MailChimp', 'espresso_mailchimp_plugin_settings'), 10, 2);
+            add_filter('plugin_action_links', ['EE_MailChimp', 'espresso_mailchimp_plugin_settings'], 10, 2);
         }
     }
+
 
     /**
      * Add a settings link to the Plugins page.
      *
-     * @param array $links  List of existing links.
+     * @param array  $links List of existing links.
      * @param string $file  Main plugins file name.
      * @return array  Updated Links list
      */
     public static function espresso_mailchimp_plugin_settings($links, $file)
     {
         if ($file === ESPRESSO_MAILCHIMP_BASE_NAME) {
-// before other links
-            array_unshift($links, '<a href="admin.php?page='. ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG .'">' . __('Settings', 'event_espresso') . '</a>');
+            $link = 'admin.php?page=' . ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG;
+            // before other links
+            array_unshift(
+                $links,
+                '<a href="' . $link . '">' . esc_html__('Settings', 'event_espresso') . '</a>'
+            );
         }
         return $links;
-    }
-
-    /**
-     * Overrides parent so we return a name that integrates properly
-     * with the data migration scripts
-     * @return string
-     */
-    public function name()
-    {
-        return 'MailChimp';
     }
 }

--- a/EE_Mailchimp_Config.php
+++ b/EE_Mailchimp_Config.php
@@ -5,10 +5,10 @@
  *
  * Settings for the MailChimp
  *
- * @package               Event Espresso
- * @subpackage            eea-mailchimp
- * @author                Nazar Kolivoshka
- * @since                 1.0
+ * @package     Event Espresso
+ * @subpackage  eea-mailchimp
+ * @author      Nazar Kolivoshka
+ * @since       1.0
  *
  */
 class EE_Mailchimp_Config extends EE_Config_Base

--- a/EE_Mailchimp_Config.php
+++ b/EE_Mailchimp_Config.php
@@ -21,12 +21,13 @@ class EE_Mailchimp_Config extends EE_Config_Base
 
 
     /**
-     * @return EE_Mailchimp_Config
+     * EE_Mailchimp_Config constructor.
      */
     public function __construct()
     {
         $this->api_settings = new EE_Mailchimp_Config_Api_Settings();
     }
+
 
     /**
      *
@@ -36,8 +37,8 @@ class EE_Mailchimp_Config extends EE_Config_Base
      */
     public function to_flat_array()
     {
-        $flattened_vars = array();
-        $properties = get_object_vars($this);
+        $flattened_vars = [];
+        $properties     = get_object_vars($this);
         foreach ($properties as $name => $property) {
             if ($property instanceof EE_Config_Base) {
                 $sub_config_properties = get_object_vars($property);
@@ -49,55 +50,5 @@ class EE_Mailchimp_Config extends EE_Config_Base
             }
         }
         return $flattened_vars;
-    }
-}
-
-
-/**
- * Class EE_Mailchimp_Config_Api_Settings
- *
- * Description
- *
- * @package               Event Espresso
- * @subpackage            eea-mailchimp
- * @author                Nazar Kolivoshka
- * @since                 1.0
- *
- */
-class EE_Mailchimp_Config_Api_Settings extends EE_Config_Base
-{
-
-    /**
-     * @var string $api_key
-     */
-    public $api_key;
-    /**
-     * @var bool $skip_double_optin
-     */
-    public $skip_double_optin;
-    /**
-     * @var bool $mc_active
-     */
-    public $mc_active;
-    /**
-     * @var string $submit_to_mc_when
-     */
-    public $submit_to_mc_when;
-    /**
-     * @var string $emails_type
-     */
-    public $emails_type;
-
-
-    /**
-     * @return EE_Mailchimp_Config_Api_Settings
-     */
-    public function __construct()
-    {
-        $this->api_key = '';
-        $this->skip_double_optin = true;
-        $this->mc_active = false;
-        $this->submit_to_mc_when = 'reg-step-approved';
-        $this->emails_type = 'html';
     }
 }

--- a/EE_Mailchimp_Config_Api_Settings.php
+++ b/EE_Mailchimp_Config_Api_Settings.php
@@ -3,12 +3,8 @@
 /**
  * Class EE_Mailchimp_Config_Api_Settings
  *
- * Description
- *
- * @package               Event Espresso
- * @subpackage            eea-mailchimp
- * @author                Nazar Kolivoshka
- * @since                 1.0
+ * @author Nazar Kolivoshka
+ * @since 1.0
  *
  */
 class EE_Mailchimp_Config_Api_Settings extends EE_Config_Base

--- a/EE_Mailchimp_Config_Api_Settings.php
+++ b/EE_Mailchimp_Config_Api_Settings.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Class EE_Mailchimp_Config_Api_Settings
+ *
+ * Description
+ *
+ * @package               Event Espresso
+ * @subpackage            eea-mailchimp
+ * @author                Nazar Kolivoshka
+ * @since                 1.0
+ *
+ */
+class EE_Mailchimp_Config_Api_Settings extends EE_Config_Base
+{
+
+    /**
+     * @var string $api_key
+     */
+    public $api_key;
+
+    /**
+     * @var bool $skip_double_optin
+     */
+    public $skip_double_optin;
+
+    /**
+     * @var bool $mc_active
+     */
+    public $mc_active;
+
+    /**
+     * @var string $submit_to_mc_when
+     */
+    public $submit_to_mc_when;
+
+    /**
+     * @var string $emails_type
+     */
+    public $emails_type;
+
+
+    /**
+     * EE_Mailchimp_Config_Api_Settings constructor.
+     */
+    public function __construct()
+    {
+        $this->api_key           = '';
+        $this->skip_double_optin = true;
+        $this->mc_active         = false;
+        $this->submit_to_mc_when = 'reg-step-approved';
+        $this->emails_type       = 'html';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-EE Mailchimp Add-on
+EE MailChimp Add-on
 =========
 
 [![Latest Release](https://img.shields.io/github/tag/eventespresso/eea-mailchimp.svg?style=flat&label=Latest%20Release)](https://github.com/eventespresso/eea-mailchimp/releases)
@@ -29,11 +29,11 @@ We follow a set pattern for releases and development of all our official add-ons
 1. Active development for new features happens on a **FET-{ticket-number}-{brief-description}** branch.  We continually merge master into the feature branch while it's in development.  Once it's complete, then testing is done on it and it's merged back to master ready for release.
 2. Bug fixes are done on a **BUG-{ticket-number}-{brief-description}** branch.  Same methodology is used as with feature branches.
 3. Master is technically always production ready and release ready but may not be equal to what the current stable release is for.
-4. When we do an official release of an add-on, the current master is tagged and the release is the zip for that tag.
+4. When we do an official release of an add-on, the current master is tagged, and the release is the zip for that tag.
 
 ### Testing
 For all testers of this add-on, please take note of the following when reporting issues.
-1. There is a difference between a feature and a bug, we consider a bug is something that reveals brokenness in intended functionality.  A feature, is something beyond intended functionality.  To help determine the difference, think about your issue like this, "I know A does C, however I *wish* it did D."  If you find yourself saying that, its a feature.  This repository is **not** the place to suggest a new feature UNLESS you've already got a pull request to implement it (see pull requests section below).  Info on sponsoring new features can [be found here](https://eventespresso.com/rich-features/sponsor-new-features/).  If you aren't sure whether something is a feature or bug feel free to post the issue - however we give priority to bug issues here.
+1. There is a difference between a feature and a bug, we consider a bug is something that reveals brokenness in intended functionality.  A feature, is something beyond intended functionality.  To help determine the difference, think about your issue like this, "I know A does C, however I *wish* it did D."  If you find yourself saying that, it's a feature.  This repository is **not** the place to suggest a new feature UNLESS you've already got a pull request to implement it (see pull requests section below).  Info on sponsoring new features can [be found here](https://eventespresso.com/rich-features/sponsor-new-features/).  If you aren't sure whether something is a feature or bug feel free to post the issue - however we give priority to bug issues here.
 2. UI/UX issues may be considered a bug but not if it requires a major change in design.  Feel free to report things you find confusing or needing improvement however reports accompanied by a pull request will likely get faster attention.
 3. Report your issue as clearly as possible.  By "clear" we mean:
 
@@ -45,14 +45,16 @@ For all testers of this add-on, please take note of the following when reporting
 
 	iv. Use URLs for the page the issue to place on where possible.
 
-1. Don't "bump" bug reports if we don't respond right away.  We see every report coming in, but we'll only reply if we need clarification or if we think its invalid.  Otherwise, we're likely working on a fix and the issue will be updated when the fix is complete.
+1. Don't "bump" bug reports if we don't respond right away.  We see every report coming in, but we'll only reply if 
+   we need clarification or if we think its invalid.  Otherwise, we're likely working on a fix, and the issue will be updated when the fix is complete.
 
 ### Pull Requests
 One of the reasons we created this private repo on GitHub is because we wanted to open up EE development to 3rd party developers who might want to contribute to the codebase. GitHub makes this really easy to do so via pull requests.  If you don't know what pull requests are, please read up on them via the GitHub help/documentation.
 
 Here's how we deal with pull requests for our repo:
 
-1. Any new FEATURES in a pull request should be based off of the *master* branch. If your feature pull request is based off any other branch it will not be considered.
+1. Any new FEATURES in a pull request should be based off of the *master* branch. If your feature pull request is 
+   based off any other branch, it will not be considered.
 2. Any BUGFIX pull requests should be based off of the branch the bug was found.  Please verify if it is in master before submitting the pull request.  If it is in reproducible on master, then the pull-request should be based off of master.
 3. We greatly appreciate any pull-requests submitted for consideration, but please understand we are very selective in what we decide to include in our official add-ons.  If the "feature" is something that expands too much on our design decisions for this add-on then we may suggest you develop your pull request into a different add-on for EE.
 

--- a/admin/mailchimp/Mailchimp_Admin_Page.core.php
+++ b/admin/mailchimp/Mailchimp_Admin_Page.core.php
@@ -239,13 +239,9 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
             } else {
                 $key_valid   = false;
                 $mcapi_error = $mci_controller->mci_get_response_error();
-                $error_msg   =
-                    isset($mcapi_error['msg'])
-                        ? $mcapi_error['msg']
-                        : esc_html__(
-                        'Unknown MailChimp API Error.',
-                        'event_espresso'
-                    );
+                $error_msg   = isset($mcapi_error['msg'])
+                    ? $mcapi_error['msg']
+                    : esc_html__('Unknown MailChimp API Error.', 'event_espresso');
                 EE_Error::add_error($error_msg, __FILE__, __FUNCTION__, __LINE__);
                 $query_args['mcapi_error']               = $error_msg;
                 $config->api_settings->mc_active         = false;

--- a/admin/mailchimp/Mailchimp_Admin_Page.core.php
+++ b/admin/mailchimp/Mailchimp_Admin_Page.core.php
@@ -1,9 +1,8 @@
 <?php
 /**
-* This contains the logic for setting up the Custom MailChimp Settings Page.
-*
-**/
-
+ * This contains the logic for setting up the Custom MailChimp Settings Page.
+ *
+ */
 class Mailchimp_Admin_Page extends EE_Admin_Page
 {
 
@@ -12,70 +11,80 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
         parent::__construct($routing);
     }
 
+
     protected function _init_page_props()
     {
-        $this->page_slug = ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG;
+        $this->page_slug  = ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG;
         $this->page_label = EE_MAILCHIMP_LABEL;
     }
+
 
     protected function _ajax_hooks()
     {
         // todo: all hooks for ajax goes here.
     }
 
+
     protected function _define_page_props()
     {
-        $this->_admin_base_url = EE_MAILCHIMP_ADMIN_URL;
+        $this->_admin_base_url   = EE_MAILCHIMP_ADMIN_URL;
         $this->_admin_page_title = $this->page_label;
-        $this->_labels = array(
-            'buttons' => array(
-                'clear_logs' => esc_html__('Clear All MailChimp Logs', 'event_espresso')
-            )
-        );
+        $this->_labels           = [
+            'buttons' => [
+                'clear_logs' => esc_html__('Clear All MailChimp Logs', 'event_espresso'),
+            ],
+        ];
     }
+
 
     protected function _set_page_routes()
     {
-        $this->_page_routes = array(
-            'default' => array(
-                'func' => '_mailchimp_api_settings'
-            ),
-            'update_mailchimp'  => array(
-                'func' => '_update_mailchimp',
-                'noheader' => true
-            ),
-            'log'=> array(
-                'func'=> '_log_overview_list_table',
-            ),
-            'clear_logs' => array(
-                'func' => '_clear_logs',
-                'noheader' => true
-            )
-        );
+        $this->_page_routes = [
+            'default'          => [
+                'func' => '_mailchimp_api_settings',
+            ],
+            'update_mailchimp' => [
+                'func'     => '_update_mailchimp',
+                'noheader' => true,
+            ],
+            'log'              => [
+                'func' => '_log_overview_list_table',
+            ],
+            'clear_logs'       => [
+                'func'     => '_clear_logs',
+                'noheader' => true,
+            ],
+        ];
     }
+
 
     protected function _set_page_config()
     {
-        $this->_page_config = array(
-            'default' => array(
-                'nav' => array(
-                    'label' => __('Main Settings', 'event_espresso'),
-                    'order' => 10
-                ),
-                'metaboxes' => array( '_publish_post_box', '_espresso_news_post_box', '_espresso_links_post_box', '_espresso_sponsors_post_box' , '_mailchimp_meta_boxes' )
-            ),
-            'log'=>array(
-                'nav'=> array(
-                    'label' => __("Logs", 'event_espresso'),
-                    'order'=>30,
-                ),
-                'list_table'=>'Mailchimp_Log_Admin_List_Table',
-                'metaboxes' => $this->_default_espresso_metaboxes,
-                'require_nonce'=> false
-            )
-        );
+        $this->_page_config = [
+            'default' => [
+                'nav'       => [
+                    'label' => esc_html__('Main Settings', 'event_espresso'),
+                    'order' => 10,
+                ],
+                'metaboxes' => [
+                    '_publish_post_box',
+                    '_espresso_news_post_box',
+                    '_espresso_links_post_box',
+                    '_espresso_sponsors_post_box',
+                    '_mailchimp_meta_boxes',
+                ],
+            ],
+            'log'     => [
+                'nav'           => [
+                    'label' => esc_html__("Logs", 'event_espresso'),
+                    'order' => 30,
+                ],
+                'list_table'    => 'Mailchimp_Log_Admin_List_Table',
+                'metaboxes'     => $this->_default_espresso_metaboxes,
+                'require_nonce' => false,
+            ],
+        ];
     }
-
 
 
     /**
@@ -87,57 +96,72 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
     }
 
 
-
     /**
-     *      declare price details page metaboxes
-     *      @access protected
-     *      @return void
+     * declare price details page metaboxes
+     *
+     * @return void
      */
     protected function _mailchimp_meta_boxes()
     {
-        add_meta_box('mailchimp-instructions-mbox', __('MailChimp Instructions', 'event_espresso'), array( $this, '_mailchimp_instructions_meta_box' ), $this->wp_page_slug, 'normal', 'high');
-        add_meta_box('mailchimp-details-mbox', __('API Settings', 'event_espresso'), array( $this, '_mailchimp_api_settings_meta_box' ), $this->wp_page_slug, 'normal', 'high');
+        add_meta_box(
+            'mailchimp-instructions-mbox',
+            esc_html__('MailChimp Instructions', 'event_espresso'),
+            [$this, '_mailchimp_instructions_meta_box'],
+            $this->wp_page_slug,
+            'normal',
+            'high'
+        );
+        add_meta_box(
+            'mailchimp-details-mbox',
+            esc_html__('API Settings', 'event_espresso'),
+            [$this, '_mailchimp_api_settings_meta_box'],
+            $this->wp_page_slug,
+            'normal',
+            'high'
+        );
     }
 
 
-
     /**
-     *      _mailchimp_api_settings_meta_box
-     *      @access public
-     *      @return void
+     * @return void
      */
     public function _mailchimp_api_settings_meta_box()
     {
-        echo EEH_Template::display_template(EE_MAILCHIMP_TEMPLATE_PATH . 'mailchimp_api_settings.template.php', $this->_template_args, true);
+        echo EEH_Template::display_template(
+            EE_MAILCHIMP_TEMPLATE_PATH . 'mailchimp_api_settings.template.php',
+            $this->_template_args,
+            true
+        );
     }
 
 
-
     /**
-     *      _edit_price_details_meta_box
-     *      @access public
-     *      @return void
+     * @return void
      */
     public function _mailchimp_instructions_meta_box()
     {
-        echo EEH_Template::display_template(EE_MAILCHIMP_TEMPLATE_PATH . 'mailchimp_instructions.template.php', $this->_template_args, true);
+        echo EEH_Template::display_template(
+            EE_MAILCHIMP_TEMPLATE_PATH . 'mailchimp_instructions.template.php',
+            $this->_template_args,
+            true
+        );
     }
 
 
-
     /**
-     *      _mailchimp_api_settings
-     *      @access protected
-     *      @return void
+     * @return void
+     * @throws EE_Error
      */
     protected function _mailchimp_api_settings()
     {
-
         $config = EED_Mailchimp::get_config();
         // d( $config );
-        $this->_template_args['mailchimp_double_opt_check'] =  isset($config->api_settings->skip_double_optin) && $config->api_settings->skip_double_optin === false ? 'checked="checked"' : '';
+        $this->_template_args['mailchimp_double_opt_check'] =
+            isset($config->api_settings->skip_double_optin) && $config->api_settings->skip_double_optin === false
+                ? 'checked="checked"' : '';
         // When do we want to submit the registrant to the MC.
-        $this->_template_args['submit_to_mc_end'] = $this->_template_args['submit_to_mc_complete'] = $this->_template_args['submit_to_mc_approved'] = '';
+        $this->_template_args['submit_to_mc_end'] =
+        $this->_template_args['submit_to_mc_complete'] = $this->_template_args['submit_to_mc_approved'] = '';
         switch ($config->api_settings->submit_to_mc_when) {
             case 'attendee-information-end':
                 $this->_template_args['submit_to_mc_end'] = 'selected';
@@ -146,8 +170,6 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
                 $this->_template_args['submit_to_mc_complete'] = 'selected';
                 break;
             case 'reg-step-approved':
-                $this->_template_args['submit_to_mc_approved'] = 'selected';
-                break;
             default:
                 $this->_template_args['submit_to_mc_approved'] = 'selected';
                 break;
@@ -155,30 +177,32 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
         // What type of emails do we want to send to the subscriber.
         $this->_template_args['mailchimp_html_emails'] = $this->_template_args['mailchimp_text_emails'] = '';
         switch ($config->api_settings->emails_type) {
-            case 'html':
-                $this->_template_args['mailchimp_html_emails'] = 'selected';
-                break;
             case 'text':
                 $this->_template_args['mailchimp_text_emails'] = 'selected';
                 break;
+            case 'html':
             default:
                 $this->_template_args['mailchimp_html_emails'] = 'selected';
                 break;
         }
 
-        $this->_template_args['mailchimp_api_key'] = isset($config->api_settings, $config->api_settings->api_key) ? $config->api_settings->api_key : '';
+        $this->_template_args['mailchimp_api_key'] =
+            isset($config->api_settings, $config->api_settings->api_key) ? $config->api_settings->api_key : '';
         if (isset($this->_req_data['mcapi_error']) && ! empty($this->_req_data['mcapi_error'])) {
-            $this->_template_args['mailchimp_key_error'] = '<span class="important-notice">' . $this->_req_data['mcapi_error'] . '</span>';
+            $this->_template_args['mailchimp_key_error']     =
+                '<span class="important-notice">' . $this->_req_data['mcapi_error'] . '</span>';
             $this->_template_args['mailchimp_api_key_class'] = 'error';
-            $this->_template_args['mailchimp_api_key_img'] = '<span class="dashicons dashicons-no pink-icon ee-icon-size-24"></span>';
+            $this->_template_args['mailchimp_api_key_img']   =
+                '<span class="dashicons dashicons-no pink-icon ee-icon-size-24"></span>';
         } elseif (! empty($this->_template_args['mailchimp_api_key'])) {
-            $this->_template_args['mailchimp_key_error'] = null;
+            $this->_template_args['mailchimp_key_error']     = null;
             $this->_template_args['mailchimp_api_key_class'] = '';
-            $this->_template_args['mailchimp_api_key_img'] = '<span class="dashicons dashicons-yes green-icon ee-icon-size-24"></span>';
+            $this->_template_args['mailchimp_api_key_img']   =
+                '<span class="dashicons dashicons-yes green-icon ee-icon-size-24"></span>';
         } else {
-            $this->_template_args['mailchimp_key_error'] = null;
+            $this->_template_args['mailchimp_key_error']     = null;
             $this->_template_args['mailchimp_api_key_class'] = '';
-            $this->_template_args['mailchimp_api_key_img'] = '';
+            $this->_template_args['mailchimp_api_key_img']   = '';
         }
 
         $this->_set_publish_post_box_vars('id', 1, false, null, false);
@@ -188,126 +212,164 @@ class Mailchimp_Admin_Page extends EE_Admin_Page
     }
 
 
-
     /**
      *  _update_mailchimp
      *  validates and saves the MailChimp API key to the config
      */
     protected function _update_mailchimp()
     {
-        $query_args = array( 'action' => 'default' );
-        /** @type EE_Mailchimp_Config $config */
+        $query_args = ['action' => 'default'];
         $config = EED_Mailchimp::get_config();
         if (isset($_POST['mailchimp_api_key']) && ! empty($_POST['mailchimp_api_key'])) {
             $mailchimp_api_key = sanitize_text_field($_POST['mailchimp_api_key']);
-            $mci_controller = new EE_MCI_Controller($mailchimp_api_key);
+            $mci_controller    = new EE_MCI_Controller($mailchimp_api_key);
             // Validate the MailChimp API Key
             $key_valid = $mci_controller->mci_get_api_key();
             if ($key_valid) {
-                $key_valid = true;
-                $config->api_settings->mc_active = 1;
-                $config->api_settings->api_key = $mailchimp_api_key;
-                $config->api_settings->skip_double_optin = empty($_POST['mailchimp_double_opt']) ? true : false;
-                $config->api_settings->emails_type = empty($_POST['emails_type']) ? 'html' : $_POST['emails_type'];
-                $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when']) ? 'reg-step-approved' : $_POST['submit_to_mc_when'];
+                $key_valid                               = true;
+                $config->api_settings->mc_active         = 1;
+                $config->api_settings->api_key           = $mailchimp_api_key;
+                $config->api_settings->skip_double_optin = empty($_POST['mailchimp_double_opt']);
+                $config->api_settings->emails_type       = empty($_POST['emails_type'])
+                    ? 'html'
+                    : sanitize_text_field($_POST['emails_type']);
+                $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when'])
+                    ? 'reg-step-approved'
+                    : sanitize_text_field($_POST['submit_to_mc_when']);
             } else {
-                $key_valid = false;
+                $key_valid   = false;
                 $mcapi_error = $mci_controller->mci_get_response_error();
-                $error_msg = isset($mcapi_error['msg']) ? $mcapi_error['msg'] : __('Unknown MailChimp API Error.', 'event_espresso');
+                $error_msg   =
+                    isset($mcapi_error['msg'])
+                        ? $mcapi_error['msg']
+                        : esc_html__(
+                        'Unknown MailChimp API Error.',
+                        'event_espresso'
+                    );
                 EE_Error::add_error($error_msg, __FILE__, __FUNCTION__, __LINE__);
-                $query_args['mcapi_error'] = $error_msg;
-                $config->api_settings->mc_active = false;
-                $config->api_settings->api_key = '';
-                $config->api_settings->emails_type = empty($_POST['emails_type']) ? 'html' : $_POST['emails_type'];
-                $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when']) ? 'reg-step-approved' : $_POST['submit_to_mc_when'];
+                $query_args['mcapi_error']               = $error_msg;
+                $config->api_settings->mc_active         = false;
+                $config->api_settings->api_key           = '';
+                $config->api_settings->emails_type       = empty($_POST['emails_type'])
+                    ? 'html'
+                    : sanitize_text_field($_POST['emails_type']);
+                $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when'])
+                    ? 'reg-step-approved'
+                    : sanitize_text_field($_POST['submit_to_mc_when']);
             }
         } else {
             $key_valid = false;
-            $error_msg = __('Please enter a MailChimp API key.', 'event_espresso');
+            $error_msg = esc_html__('Please enter a MailChimp API key.', 'event_espresso');
             EE_Error::add_error($error_msg, __FILE__, __FUNCTION__, __LINE__);
-            $query_args['mcapi_error'] = $error_msg;
-            $config->api_settings->mc_active = false;
-            $config->api_settings->api_key = '';
-            $config->api_settings->emails_type = empty($_POST['emails_type']) ? 'html' : $_POST['emails_type'];
-            $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when']) ? 'reg-step-approved' : $_POST['submit_to_mc_when'];
+            $query_args['mcapi_error']               = $error_msg;
+            $config->api_settings->mc_active         = false;
+            $config->api_settings->api_key           = '';
+            $config->api_settings->emails_type       = empty($_POST['emails_type'])
+                ? 'html'
+                : sanitize_text_field($_POST['emails_type']);
+            $config->api_settings->submit_to_mc_when = empty($_POST['submit_to_mc_when'])
+                ? 'reg-step-approved'
+                : sanitize_text_field($_POST['submit_to_mc_when']);
         }
         EED_Mailchimp::update_config($config);
         if (isset($query_args['mcapi_error'])) {
             $query_args['mcapi_error'] = urlencode($query_args['mcapi_error']);
         }
-        $this->_redirect_after_action($key_valid, 'Mailchimp API Key', 'updated', $query_args);
+        $this->_redirect_after_action($key_valid, 'MailChimp API Key', 'updated', $query_args);
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     protected function _log_overview_list_table()
     {
-//      $this->_search_btn_label = __('Payment Log', 'event_espresso');
         $this->display_admin_list_table_page_with_sidebar();
     }
 
+
     protected function _set_list_table_views_log()
     {
-        $this->_views = array(
-            'all' => array(
-                'slug' => 'all',
-                'label' => __('View All Logs', 'event_espresso'),
+        $this->_views = [
+            'all' => [
+                'slug'  => 'all',
+                'label' => esc_html__('View All Logs', 'event_espresso'),
                 'count' => 0,
-            )
-        );
+            ],
+        ];
     }
 
+
+    /**
+     * @param int   $per_page
+     * @param int   $current_page
+     * @param false $count
+     * @return EE_Base_Class[]|int
+     * @throws EE_Error
+     */
     public function get_logs($per_page = 50, $current_page = 0, $count = false)
     {
-        $query_params = array(
-            array(
-                'LOG_type' => EED_Mailchimp::log_type
-            ),
-            'order_by' => array(
-                'LOG_time' => 'DESC'
-            )
-        );
+        $query_params = [
+            [
+                'LOG_type' => EED_Mailchimp::log_type,
+            ],
+            'order_by' => [
+                'LOG_time' => 'DESC',
+            ],
+        ];
         if ($count) {
             return EEM_Change_Log::instance()->count($query_params);
         } else {
-            $query_params['limit'] =  array( ( $current_page - 1 ) * $per_page, $per_page );
-            return  EEM_Change_Log::instance()->get_all($query_params);
+            $query_params['limit'] = [($current_page - 1) * $per_page, $per_page];
+            return EEM_Change_Log::instance()->get_all($query_params);
         }
     }
 
+
+    /**
+     * @throws EE_Error
+     */
     protected function _clear_logs()
     {
         $deleted = EEM_Change_Log::instance()->delete(
-            array(
-                array(
-                    'LOG_type' => EED_Mailchimp::log_type
-                )
-            )
+            [
+                [
+                    'LOG_type' => EED_Mailchimp::log_type,
+                ],
+            ]
         );
         $this->_redirect_after_action(
             $deleted,
             esc_html__('MailChimp Log Entries', 'event_espresso'),
             esc_html__('deleted', 'event_espresso'),
-            array(
-                'action' => 'log'
-            )
+            [
+                'action' => 'log',
+            ]
         );
     }
-
-
 
 
     // none of the below group are currently used for this page
     protected function _add_screen_options()
     {
     }
+
+
     protected function _add_feature_pointers()
     {
     }
+
+
     public function admin_init()
     {
     }
+
+
     public function admin_notices()
     {
     }
+
+
     public function admin_footer_scripts()
     {
     }

--- a/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
+++ b/admin/mailchimp/Mailchimp_Admin_Page_Init.core.php
@@ -1,38 +1,45 @@
 <?php
 /**
-* A child class for initialising the MailChimp Settings Page in the list of EE settings pages
-*
-**/
+ * A child class for initialising the MailChimp Settings Page in the list of EE settings pages
+ *
+ **/
 
 class Mailchimp_Admin_Page_Init extends EE_Admin_Page_Init
 {
 
     public function __construct()
     {
-        do_action('AHEE_log', __FILE__, __FUNCTION__, '');
-        define('EE_MAILCHIMP_LABEL', __('Mailchimp', 'event_espresso'));
+        define('EE_MAILCHIMP_LABEL', esc_html__('MailChimp', 'event_espresso'));
         define('EE_MAILCHIMP_ADMIN_URL', admin_url('admin.php?page=' . ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG));
-        define('EE_MAILCHIMP_TEMPLATE_PATH', ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp/templates/');
+        define('EE_MAILCHIMP_TEMPLATE_PATH', ESPRESSO_MAILCHIMP_ADMIN_DIR . 'templates/');
         parent::__construct();
-        $this->_folder_path = ESPRESSO_MAILCHIMP_ADMIN_DIR . 'mailchimp' . DS;
+        $this->_folder_path = ESPRESSO_MAILCHIMP_ADMIN_DIR;
     }
+
 
     protected function _set_init_properties()
     {
         $this->label = EE_MAILCHIMP_LABEL;
     }
 
+
+    /**
+     * @return array|void
+     * @throws EE_Error
+     */
     protected function _set_menu_map()
     {
-        $this->_menu_map = new EE_Admin_Page_Sub_Menu(array(
-        'menu_group' => 'addons',
-        'menu_order' => 10,
-        'show_on_menu' => true,
-        'parent_slug' => 'espresso_events',
-        'menu_slug' => ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG,
-        'menu_label' => EE_MAILCHIMP_LABEL,
-        'capability' => 'manage_options',
-        'admin_init_page' => $this
-        ));
+        $this->_menu_map = new EE_Admin_Page_Sub_Menu(
+            [
+                'menu_group'      => 'addons',
+                'menu_order'      => 10,
+                'show_on_menu'    => true,
+                'parent_slug'     => 'espresso_events',
+                'menu_slug'       => ESPRESSO_MAILCHIMP_SETTINGS_PAGE_SLUG,
+                'menu_label'      => EE_MAILCHIMP_LABEL,
+                'capability'      => 'manage_options',
+                'admin_init_page' => $this,
+            ]
+        );
     }
 }

--- a/admin/mailchimp/Mailchimp_Log_Admin_List_Table.class.php
+++ b/admin/mailchimp/Mailchimp_Log_Admin_List_Table.class.php
@@ -10,32 +10,31 @@
  * @package     Registration_Form_Questions_Admin_List_Table
  * @subpackage  includes/core/admin/events/Registration_Form_Questions_Admin_List_Table.class.php
  * @author      Darren Ethier
- *
- * ------------------------------------------------------------------------
  */
 class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
 {
 
     /**
-     * @param \EE_Admin_Page $admin_page
+     * @param EE_Admin_Page $admin_page
      * @return Mailchimp_Log_Admin_List_Table
      */
-    public function __construct($admin_page)
+    public function __construct(EE_Admin_Page $admin_page)
     {
         parent::__construct($admin_page);
     }
 
 
-
     /**
      * _setup_data
+     *
      * @return void
      */
     protected function _setup_data()
     {
-        $this->_data = $this->_admin_page->get_logs($this->_per_page, $this->_current_page);
+        $this->_data           = $this->_admin_page->get_logs($this->_per_page, $this->_current_page);
         $this->_all_data_count = $this->_admin_page->get_logs($this->_per_page, $this->_current_page, true);
     }
+
 
     protected function _get_table_filters()
     {
@@ -43,45 +42,45 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-
     /**
      * _set_properties
+     *
      * @return void
      */
     protected function _set_properties()
     {
-        $this->_wp_list_args = array(
-            'singular' => __('MailChimp Log', 'event_espresso'),
-            'plural' => __('MailChimp Logs', 'event_espresso'),
-            'ajax' => true, // for now,
-            'screen' => $this->_admin_page->get_current_screen()->id
-            );
+        $this->_wp_list_args = [
+            'singular' => esc_html__('MailChimp Log', 'event_espresso'),
+            'plural'   => esc_html__('MailChimp Logs', 'event_espresso'),
+            'ajax'     => true, // for now,
+            'screen'   => $this->_admin_page->get_current_screen()->id,
+        ];
 
-        $this->_columns = array(
-            'cb' => '<input type="checkbox" />',
-            'id' => __('ID', 'event_espresso'),
-            'LOG_time' => __('Time', 'event_espresso'),
-            'REG_ID' => __('Registration', 'event_espresso'),
-            'LOG_message' => __('Log Message', 'event_espresso'),
-            );
+        $this->_columns = [
+            'cb'          => '<input type="checkbox" />',
+            'id'          => esc_html__('ID', 'event_espresso'),
+            'LOG_time'    => esc_html__('Time', 'event_espresso'),
+            'REG_ID'      => esc_html__('Registration', 'event_espresso'),
+            'LOG_message' => esc_html__('Log Message', 'event_espresso'),
+        ];
 
-        $this->_sortable_columns = array(
-            'LOG_time' => array( 'LOG_time' => true ),
-            );
+        $this->_sortable_columns = [
+            'LOG_time' => ['LOG_time' => true],
+        ];
 
-        $this->_hidden_columns = array(
-            );
-        $this->_bottom_buttons = array(
-                'clear_logs' => array(
-                        'route' => 'clear_logs',
-                )
-        );
+        $this->_hidden_columns = [
+        ];
+        $this->_bottom_buttons = [
+            'clear_logs' => [
+                'route' => 'clear_logs',
+            ],
+        ];
     }
-
 
 
     /**
      * _add_view_counts
+     *
      * @return void
      */
     protected function _add_view_counts()
@@ -90,10 +89,10 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-
     /**
      * column_cb
-     * @param \EE_Change_Log $item
+     *
+     * @param EE_Change_Log $item
      * @return string
      */
     public function column_cb($item)
@@ -102,11 +101,13 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-
     /**
      * column_id
-     * @param \EE_Change_Log $item
+     *
+     * @param EE_Change_Log $item
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_id(EE_Change_Log $item)
     {
@@ -114,11 +115,13 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-
     /**
      * column_LOG_time
-     * @param \EE_Change_Log $item
+     *
+     * @param EE_Change_Log $item
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_LOG_time(EE_Change_Log $item)
     {
@@ -126,11 +129,12 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
     }
 
 
-
     /**
      * column_PMD_ID
-     * @param \EE_Change_Log $item
+     *
+     * @param EE_Change_Log $item
      * @return string
+     * @throws EE_Error
      */
     public function column_REG_ID(EE_Change_Log $item)
     {
@@ -144,19 +148,21 @@ class Mailchimp_Log_Admin_List_Table extends EE_Admin_List_Table
             }
             return '<a href="' . $reg->get_admin_details_link() . '">' . $name . '</a>';
         } else {
-            return __("No longer exists", 'event_espresso');
+            return esc_html__("No longer exists", 'event_espresso');
         }
     }
 
 
-
     /**
      * column_TXN_ID
-     * @param \EE_Change_Log $item
+     *
+     * @param EE_Change_Log $item
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function column_LOG_message(EE_Change_Log $item)
     {
         return $item->get_pretty('LOG_message', 'as_table');
     }
-} //end class Registration_Form_Questions_Admin_List_Table
+}

--- a/admin/mailchimp/templates/mailchimp_api_settings.template.php
+++ b/admin/mailchimp/templates/mailchimp_api_settings.template.php
@@ -1,76 +1,140 @@
 <?php
-/** @type string $mailchimp_api_key */
-/** @type string $mailchimp_api_key_class */
-/** @type string $mailchimp_api_key_img */
-/** @type string $mailchimp_double_opt_check */
+/**
+ * @type string $mailchimp_api_key
+ * @type string $mailchimp_key_error
+ * @type string $mailchimp_api_key_class
+ * @type string $mailchimp_api_key_img
+ * @type string $mailchimp_double_opt_check
+ * @type string $mailchimp_html_emails
+ * @type string $mailchimp_text_emails
+ * @type string $submit_to_mc_end
+ * @type string $submit_to_mc_complete
+ * @type string $submit_to_mc_approved
+ */
+
 ?>
 <div class='inside'>
     <table class="mailchimp_api_keybox form-table">
         <tbody>
-            <tr valign="top">
-                <th><label for="mailchimp_api_key"><?php _e('Your MailChimp API Key:', 'event_espresso'); ?></th>
-                <td>
-                    <?php echo $mailchimp_key_error; ?>
-                    <input size="45" type="text" name="mailchimp_api_key" id="ee-mailchimp-api-key"  class="<?php echo $mailchimp_api_key_class; ?>" value="<?php echo $mailchimp_api_key; ?>"/><?php echo $mailchimp_api_key_img; ?>
-                    <p class="description">
+        <tr valign="top">
+            <th>
+                <label for="ee-mailchimp-api-key">
+                    <?php
+                    esc_html_e('Your MailChimp API Key:', 'event_espresso'); ?>
+                </label>
+            </th>
+            <td>
+                <?php
+                echo $mailchimp_key_error; ?>
+                <input size="45" type="text" name="mailchimp_api_key" id="ee-mailchimp-api-key" class="<?php
+                echo $mailchimp_api_key_class; ?>" value="<?php
+                echo $mailchimp_api_key; ?>"/><?php
+                echo $mailchimp_api_key_img; ?>
+                <p class="description">
+                    <?php
+                    printf(
+                        esc_html__(
+                            '* Please %1$sclick here to learn how to create a MailChimp API key%2$s if you do not have one already.',
+                            'event_espresso'
+                        ),
+                        '<a href="http://kb.mailchimp.com/article/where-can-i-find-my-api-key/" target="_blank">',
+                        '</a>'
+                    );
+                    ?>
+                </p>
+            </td>
+        </tr>
+        <tr valign="top">
+            <th>
+                <?php
+                esc_html_e('MailChimp API Options:', 'event_espresso'); ?>
+            </th>
+            <td>
+                <input type="checkbox" id="ee-mailchimp-double-opt" name="mailchimp_double_opt" <?php
+                echo $mailchimp_double_opt_check; ?> />
+                <label for="ee-mailchimp-double-opt">
+                    <?php
+                    esc_html_e('Skip double opt-in emails.', 'event_espresso'); ?>
+                </label>
+
+                <p class="description">
+                    <?php
+                    printf(
+                        esc_html__('* %1$sClick here to read about how double opt-in works%2$s.', 'event_espresso'),
+                        '<a href="http://kb.mailchimp.com/article/how-does-confirmed-optin-or-double-optin-work/" target="_blank">',
+                        '</a>'
+                    );
+                    ?>
+                </p>
+            </td>
+        </tr>
+        <tr valign="top">
+            <th>
+                <label for='ee-mailchimp-emails_type'>
+                    <?php
+                    esc_html_e('Email content type:', 'event_espresso'); ?>
+                </label>
+            </th>
+            <td>
+                <select id="ee-mailchimp-emails_type" name="emails_type">
+                    <option value="html" <?php
+                    echo $mailchimp_html_emails; ?> >HTML
+                    </option>
+                    <option value="text" <?php
+                    echo $mailchimp_text_emails; ?> >Text
+                    </option>
+                </select>
+
+                <p class="description">
+                    <?php
+                    esc_html_e('* Type of emails to send to the subscriber.', 'event_espresso'); ?>
+                </p>
+            </td>
+        </tr>
+        <tr valign="top">
+            <th>
+                <label for='ee-mailchimp-submit_to_mc_when'>
+                    <?php
+                    esc_html_e('Submit to MailChimp when ...', 'event_espresso'); ?>
+                </label>
+            </th>
+            <td>
+                <select id="ee-mailchimp-submit_to_mc_when" name="submit_to_mc_when">
+                    <option value="attendee-information-end" <?php
+                    echo $submit_to_mc_end; ?> >
                         <?php
-                        printf(
-                            __('* Please %1$sclick here to learn how to create a MailChimp API key%2$s if you do not have one already.', 'event_espresso'),
-                            '<a href="http://kb.mailchimp.com/article/where-can-i-find-my-api-key/" target="_blank">',
-                            '</a>'
+                        esc_html_e('subscriber submits information.', 'event_espresso'); ?>
+                    </option>
+                    <option value="reg-step-completed" <?php
+                    echo $submit_to_mc_complete; ?> >
+                        <?php
+                        esc_html_e(
+                            'registration is completed (payment status does not matter).',
+                            'event_espresso'
                         );
                         ?>
-                    </p>
-                </td>
-            </tr>
-            <tr valign="top">
-                <th><label><?php _e('MailChimp API Options:', 'event_espresso'); ?></th>
-                <td>
-                    <input type="checkbox" id="ee-mailchimp-double-opt" name="mailchimp_double_opt" <?php echo $mailchimp_double_opt_check; ?> />
-                    <label for="ee-mailchimp-double-opt"><?php _e('Skip double opt-in emails.', 'event_espresso'); ?></label>
-
-                    <p class="description">
+                    </option>
+                    <option value="reg-step-approved" <?php
+                    echo $submit_to_mc_approved; ?> >
                         <?php
-                        printf(
-                            __('* %1$sClick here to read about how double opt-in works%2$s.', 'event_espresso'),
-                            '<a href="http://kb.mailchimp.com/article/how-does-confirmed-optin-or-double-optin-work/" target="_blank">',
-                            '</a>'
+                        esc_html_e(
+                            'registration is completed with an approved status.',
+                            'event_espresso'
                         );
                         ?>
-                    </p>
-                </td>
-            </tr>
-            <tr valign="top">
-                <th><?php _e('Email content type:', 'event_espresso'); ?></th>
-                <td>
-                    <select name="emails_type">
-                        <option value="html" <?php echo $mailchimp_html_emails; ?> >HTML</option>
-                        <option value="text" <?php echo $mailchimp_text_emails; ?> >Text</option>
-                    </select>
+                    </option>
+                </select>
 
-                    <p class="description">
-                        <?php
-                            _e('* Type of emails to send to the subscriber.', 'event_espresso');
-                        ?>
-                    </p>
-                </td>
-            </tr>
-            <tr valign="top">
-                <th><?php _e('Submit to MailChimp when ...', 'event_espresso'); ?></th>
-                <td>
-                    <select name="submit_to_mc_when">
-                        <option value="attendee-information-end" <?php echo $submit_to_mc_end; ?> >subscriber submits information.</option>
-                        <option value="reg-step-completed" <?php echo $submit_to_mc_complete; ?> >registration is completed (payment status does not matter).</option>
-                        <option value="reg-step-approved" <?php echo $submit_to_mc_approved; ?> >registration is completed with an approved status.</option>
-                    </select>
-
-                    <p class="description">
-                        <?php
-                            _e('* When should the attendee data be submitted to MailChimp?', 'event_espresso');
-                        ?>
-                    </p>
-                </td>
-            </tr>
+                <p class="description">
+                    <?php
+                    esc_html_e(
+                        '* When should the attendee data be submitted to MailChimp?',
+                        'event_espresso'
+                    );
+                    ?>
+                </p>
+            </td>
+        </tr>
         </tbody>
     </table>
 </div>

--- a/admin/mailchimp/templates/mailchimp_instructions.template.php
+++ b/admin/mailchimp/templates/mailchimp_instructions.template.php
@@ -1,15 +1,32 @@
 <div class='inside'>
     <div class="padding">
         <p>
-            <?php _e("With the Event Espresso MailChimp Add-On we make it easy to quickly add subscribers from any of your events. Once a visitor submits their information on your registration form, the attendee is instantly added to the MailChimp mailing list that you have configured for that event.", 'event_espresso'); ?>
+            <?php
+            esc_html_e(
+                "With the Event Espresso MailChimp Add-On we make it easy to quickly add subscribers from any of your events. Once a visitor submits their information on your registration form, the attendee is instantly added to the MailChimp mailing list that you have configured for that event.",
+                'event_espresso'
+            ); ?>
         </p>
 
         <p>
-            <?php printf(__('* A %1$sMailChimp API Key%2$s is required for this plugin.', 'event_espresso'), '<b>', '</b>'); ?>
+            <?php
+            printf(
+                esc_html__('* A %1$sMailChimp API Key%2$s is required for this plugin.', 'event_espresso'),
+                '<b>',
+                '</b>'
+            ); ?>
         </p>
 
         <p>
-            <?php printf(__('Once the API key is configured successfully, a %1$s"MailChimp List" box%2$s will appear in the right menu of the Event Creation and Event Update dialogs, which will allow you to select which MailChimp List and Group you want to integrate with..', 'event_espresso'), '<b>', '</b>'); ?>
+            <?php
+            printf(
+                esc_html__(
+                    'Once the API key is configured successfully, a %1$s"MailChimp List" box%2$s will appear in the right menu of the Event Creation and Event Update dialogs, which will allow you to select which MailChimp List and Group you want to integrate with..',
+                    'event_espresso'
+                ),
+                '<b>',
+                '</b>'
+            ); ?>
         </p>
     </div>
 </div>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	},
 	"require": {
 		"composer/installers": "~1.0",
-		"php": ">=5.5"
+		"php": ">=5.6"
 	},
 	"scripts": {
 		"config-eventespressocs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0decc709073cc01948c92948f0ccd5d0",
+    "content-hash": "e751e954fa870ab18ec17c3374f4c8b2",
     "packages": [
         {
             "name": "composer/installers",
@@ -131,6 +131,10 @@
                 "zend",
                 "zikula"
             ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.9.0"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -151,16 +155,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/eventespresso/ee-coding-standards.git",
-                "reference": "276d7999ffc6b562b7678ce78f10183e8dd1d4d2"
+                "reference": "ad21bf2ad18ec2c905b4d887b3e414f2fb80b557"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/276d7999ffc6b562b7678ce78f10183e8dd1d4d2",
-                "reference": "276d7999ffc6b562b7678ce78f10183e8dd1d4d2",
+                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/ad21bf2ad18ec2c905b4d887b3e414f2fb80b557",
+                "reference": "ad21bf2ad18ec2c905b4d887b3e414f2fb80b557",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
+                "php": ">=5.6",
                 "phpcompatibility/php-compatibility": "9.*",
                 "phpcompatibility/phpcompatibility-wp": "2.*",
                 "squizlabs/php_codesniffer": "3.*",
@@ -172,6 +176,7 @@
             "suggest": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "scripts": {
                 "config-set": [
@@ -206,7 +211,7 @@
                 "issues": "https://github.com/eventespresso/ee-coding-standards/issues",
                 "source": "https://github.com/eventespresso/ee-coding-standards/tree/master"
             },
-            "time": "2020-10-12T19:17:22+00:00"
+            "time": "2021-01-12T21:16:48+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -264,6 +269,10 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
@@ -316,6 +325,10 @@
                 "polyfill",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
             "time": "2019-11-04T15:17:54+00:00"
         },
         {
@@ -366,6 +379,10 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
             "time": "2019-08-28T14:22:28+00:00"
         },
         {
@@ -374,12 +391,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "563faed0e5e24a5b639fbd30d8f3921bb11fccc0"
+                "reference": "a2c04f857299a7119e96448249a9dd5954e099c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/563faed0e5e24a5b639fbd30d8f3921bb11fccc0",
-                "reference": "563faed0e5e24a5b639fbd30d8f3921bb11fccc0",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a2c04f857299a7119e96448249a9dd5954e099c1",
+                "reference": "a2c04f857299a7119e96448249a9dd5954e099c1",
                 "shasum": ""
             },
             "conflict": {
@@ -409,7 +426,7 @@
                 "composer/composer": "<=1-alpha.11",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": "= 4.10.0|>=4,<4.4.52|>=4.5,<4.9.6",
+                "contao/core-bundle": ">=4,<4.4.52|>=4.5,<4.9.6|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "datadog/dd-trace": ">=0.30,<0.30.2",
                 "david-garcia/phpwhois": "<=4.3.1",
@@ -431,6 +448,7 @@
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
                 "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
@@ -452,6 +470,8 @@
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "fuel/core": "<1.8.1",
                 "getgrav/grav": "<1.7-beta.8",
+                "getkirby/cms": ">=3,<3.4.5",
+                "getkirby/panel": "<2.5.14",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
@@ -503,14 +523,14 @@
                 "paragonie/random_compat": "<2",
                 "passbolt/passbolt_api": "<2.11",
                 "paypal/merchant-sdk-php": "<3.12",
-                "pear/archive_tar": "<1.4.4",
+                "pear/archive_tar": "<1.4.11",
                 "personnummer/personnummer": "<3.0.2",
                 "phpfastcache/phpfastcache": ">=5,<5.0.13",
                 "phpmailer/phpmailer": "<6.1.6",
                 "phpmussel/phpmussel": ">=1,<1.6",
                 "phpmyadmin/phpmyadmin": "<4.9.6|>=5,<5.0.3",
                 "phpoffice/phpexcel": "<1.8.2",
-                "phpoffice/phpspreadsheet": "<1.8",
+                "phpoffice/phpspreadsheet": "<1.16",
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
@@ -533,8 +553,8 @@
                 "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
-                "shopware/core": "<=6.3.2",
-                "shopware/platform": "<=6.3.2",
+                "shopware/core": "<=6.3.4",
+                "shopware/platform": "<=6.3.4",
                 "shopware/shopware": "<5.6.9",
                 "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
                 "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
@@ -670,6 +690,10 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "support": {
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
+            },
             "funding": [
                 {
                     "url": "https://github.com/Ocramius",
@@ -680,7 +704,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-23T21:01:44+00:00"
+            "time": "2020-12-31T19:24:22+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -731,6 +755,11 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
@@ -777,6 +806,11 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],
@@ -789,8 +823,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.6"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -155,12 +155,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/eventespresso/ee-coding-standards.git",
-                "reference": "ad21bf2ad18ec2c905b4d887b3e414f2fb80b557"
+                "reference": "02bbd205c470a1153a49533d29ce8b4096d937c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/ad21bf2ad18ec2c905b4d887b3e414f2fb80b557",
-                "reference": "ad21bf2ad18ec2c905b4d887b3e414f2fb80b557",
+                "url": "https://api.github.com/repos/eventespresso/ee-coding-standards/zipball/02bbd205c470a1153a49533d29ce8b4096d937c2",
+                "reference": "02bbd205c470a1153a49533d29ce8b4096d937c2",
                 "shasum": ""
             },
             "require": {
@@ -211,7 +211,7 @@
                 "issues": "https://github.com/eventespresso/ee-coding-standards/issues",
                 "source": "https://github.com/eventespresso/ee-coding-standards/tree/master"
             },
-            "time": "2021-01-12T21:16:48+00:00"
+            "time": "2021-01-12T22:54:39+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",

--- a/db/classes/EE_Event_Mailchimp_List_Group.class.php
+++ b/db/classes/EE_Event_Mailchimp_List_Group.class.php
@@ -1,46 +1,60 @@
 <?php
+
 /**
  * Class  EE_Event_Mailchimp_List_Group
  *
  * @package         Event Espresso
  * @subpackage      ee4-mailchimp
- *
- * ------------------------------------------------------------------------
  */
 class EE_Event_Mailchimp_List_Group extends EE_Base_Class
 {
-    
+
     /**
      *
-     * @param array  $props_n_values
+     * @param array $props_n_values
      * @return EE_Event_Mailchimp_List_Group
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array())
+    public static function new_instance($props_n_values = [])
     {
-        $classname = __CLASS__;
+        $classname  = __CLASS__;
         $has_object = parent::_check_for_object($props_n_values, $classname);
         return $has_object ? $has_object : new self($props_n_values);
     }
 
-    public static function new_instance_from_db($props_n_values = array())
+
+    /**
+     * @param array $props_n_values
+     * @return EE_Event_Mailchimp_List_Group
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public static function new_instance_from_db($props_n_values = [])
     {
         return new self($props_n_values, true);
     }
+
 
     /**
      * Get the MailChimp Group ID.
      *
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mc_group()
     {
         return $this->get('AMC_mailchimp_group_id');
     }
 
+
     /**
      * Get the MailChimp List ID.
      *
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mc_list()
     {

--- a/db/classes/EE_Question_Mailchimp_Field.class.php
+++ b/db/classes/EE_Question_Mailchimp_Field.class.php
@@ -1,46 +1,60 @@
 <?php
+
 /**
  * Class  EE_Question_Mailchimp_Field
  *
  * @package         Event Espresso
  * @subpackage      ee4-mailchimp
- *
- * ------------------------------------------------------------------------
  */
 class EE_Question_Mailchimp_Field extends EE_Base_Class
 {
 
     /**
      *
-     * @param array  $props_n_values
+     * @param array $props_n_values
      * @return EE_Question_Mailchimp_Field
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    public static function new_instance($props_n_values = array())
+    public static function new_instance($props_n_values = [])
     {
-        $classname = __CLASS__;
+        $classname  = __CLASS__;
         $has_object = parent::_check_for_object($props_n_values, $classname);
         return $has_object ? $has_object : new self($props_n_values);
     }
 
-    public static function new_instance_from_db($props_n_values = array())
+
+    /**
+     * @param array $props_n_values
+     * @return EE_Question_Mailchimp_Field
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
+    public static function new_instance_from_db($props_n_values = [])
     {
         return new self($props_n_values, true);
     }
+
 
     /**
      * Get the MailChimp Field ID.
      *
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mc_field()
     {
         return $this->get('QMC_mailchimp_field_id');
     }
 
+
     /**
      * Get the Event Question ID.
      *
      * @return int
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mc_event_question()
     {

--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_list_group.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_list_group.dmsstage.php
@@ -9,61 +9,98 @@ class EE_DMS_2_0_0_mc_list_group extends EE_Data_Migration_Script_Stage_Table
 
     /**
      * Old table name.
+     *
      * @access protected
      */
     protected $_old_table;
 
     /**
      * New table name.
+     *
      * @access protected
      */
     protected $_new_table;
 
+
     public function __construct()
     {
         global $wpdb;
-        $this->_pretty_name = __("Mailchimp List Group", "event_espresso");
-        $this->_old_table = $wpdb->prefix . "events_mailchimp_event_rel";
-        $this->_new_table = $wpdb->prefix . "esp_event_mailchimp_list_group";
+        $this->_pretty_name     = esc_html__("MailChimp List Group", "event_espresso");
+        $this->_old_table       = $wpdb->prefix . "events_mailchimp_event_rel";
+        $this->_new_table       = $wpdb->prefix . "esp_event_mailchimp_list_group";
         $this->_extra_where_sql = "WHERE mailchimp_list_id IS NOT NULL OR  mailchimp_list_id != ''";
         parent::__construct();
     }
 
+
     /**
      * Migrate rows from the old table to the new table 'esp_event_mailchimp_list_group'.
      *
-     * @access public
+     * @param array $old_row
+     * @throws EE_Error
      */
     protected function _migrate_old_row($old_row)
     {
         global $wpdb;
-        $migrations_ran = EE_Data_Migration_Manager::instance()->get_data_migrations_ran();
-        $core_4_1_0_migration = isset($migrations_ran['Core']) && isset($migrations_ran['Core']['4.1.0']) ? $migrations_ran['Core']['4.1.0'] : null;
+        $migrations_ran       = EE_Data_Migration_Manager::instance()->get_data_migrations_ran();
+        $core_4_1_0_migration = isset($migrations_ran['Core']) && isset($migrations_ran['Core']['4.1.0'])
+            ? $migrations_ran['Core']['4.1.0']
+            : null;
         // Get the new event IDs for the old
         if ($core_4_1_0_migration) {
-            $new_event_id = $core_4_1_0_migration->get_mapping_new_pk($wpdb->prefix.'events_detail', $old_row['event_id'], $wpdb->posts);
+            $new_event_id =
+                $core_4_1_0_migration->get_mapping_new_pk(
+                    $wpdb->prefix . 'events_detail',
+                    $old_row['event_id'],
+                    $wpdb->posts
+                );
             if (! $new_event_id) {
-                $this->add_error(sprintf(__('Could not migrate old row %s because there is no new event ID for old event with ID %s', 'event_espresso'), json_encode($old_row), $old_row['event_id']));
+                $this->add_error(
+                    sprintf(
+                        esc_html__(
+                            'Could not migrate old row %s because there is no new event ID for old event with ID %s',
+                            'event_espresso'
+                        ),
+                        json_encode($old_row),
+                        $old_row['event_id']
+                    )
+                );
             }
         } else {
             $new_event_id = 0;
-            $this->add_error(sprintf(__('Could not migrate old row %s because there is no new event ID for old event with ID %s, because we couldnt find the data for the 4.1 data migration script', 'event_espresso'), json_encode($old_row), $old_row['event_id']));
+            $this->add_error(
+                sprintf(
+                    esc_html__(
+                        'Could not migrate old row %s because there is no new event ID for old event with ID %s, because we couldnt find the data for the 4.1 data migration script',
+                        'event_espresso'
+                    ),
+                    json_encode($old_row),
+                    $old_row['event_id']
+                )
+            );
         }
 
-        $cols_n_values = array(
-            'EVT_ID' => $new_event_id,
-            'AMC_mailchimp_list_id' => $old_row['mailchimp_list_id'],
-            'AMC_mailchimp_group_id' => $old_row['mailchimp_group_id']
-        );
-        $data_types = array(
+        $cols_n_values = [
+            'EVT_ID'                 => $new_event_id,
+            'AMC_mailchimp_list_id'  => $old_row['mailchimp_list_id'],
+            'AMC_mailchimp_group_id' => $old_row['mailchimp_group_id'],
+        ];
+        $data_types    = [
             '%d',   // EVT_ID
             '%s',   // AMC_mailchimp_list_id
             '%s',   // AMC_mailchimp_group_id
-        );
-        $success = $wpdb->insert($this->_new_table, $cols_n_values, $data_types);
+        ];
+        $success       = $wpdb->insert($this->_new_table, $cols_n_values, $data_types);
         if (! $success) {
-            $this->add_error($this->get_migration_script()->_create_error_message_for_db_insertion($this->_old_table, $old_row, $this->_new_table, $cols_n_values, $data_types));
-            return 0;
+            $this->add_error(
+                $this->get_migration_script()->_create_error_message_for_db_insertion(
+                    $this->_old_table,
+                    $old_row,
+                    $this->_new_table,
+                    $cols_n_values,
+                    $data_types
+                )
+            );
         }
     }
 }

--- a/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_0_0_stages/EE_DMS_2_0_0_mc_options.dmsstage.php
@@ -6,29 +6,41 @@
 class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
 {
 
-    protected $_mc_options_to_migrate = array(
+    protected $_mc_options_to_migrate = [
         'apikey',
-    );
+    ];
 
+
+    /**
+     * EE_DMS_2_0_0_mc_options constructor.
+     */
     public function __construct()
     {
-        $this->_pretty_name = __("MailChimp Options", "event_espresso");
-        $this->_mc_options_to_migrate = apply_filters('FHEE__EE_DMS_4_1_0_mailchimp_options__mc_options_to_migrate', $this->_mc_options_to_migrate);
+        $this->_pretty_name           = esc_html__("MailChimp Options", "event_espresso");
+        $this->_mc_options_to_migrate =
+            apply_filters('FHEE__EE_DMS_4_1_0_mailchimp_options__mc_options_to_migrate', $this->_mc_options_to_migrate);
         parent::__construct();
     }
 
+
+    /**
+     * @param int $num_items
+     * @return int
+     */
     public function _migration_step($num_items = 1)
     {
-        // Get mailchimp's config.
-        if (isset(EE_Config::instance()->addons->EE_Mailchimp) && EE_Config::instance()->addons->EE_Mailchimp instanceof EE_Mailchimp_Config) {
+        // Get MailChimp's config.
+        if (isset(EE_Config::instance()->addons->EE_Mailchimp)
+            && EE_Config::instance()->addons->EE_Mailchimp instanceof EE_Mailchimp_Config
+        ) {
             $config = EE_Config::instance()->addons->EE_Mailchimp;
         } else {
-            $config = new EE_Mailchimp_Config();
+            $config                                     = new EE_Mailchimp_Config();
             EE_Config::instance()->addons->EE_Mailchimp = $config;
         }
 
         $items_actually_migrated = 0;
-        $old_mc_options = get_option('event_mailchimp_settings');
+        $old_mc_options          = get_option('event_mailchimp_settings');
         foreach ($this->_mc_options_to_migrate as $option_name) {
             // Only if there's a setting to migrate.
             if (isset($old_mc_options[ $option_name ])) {
@@ -43,7 +55,7 @@ class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
         // Activate MC if the API Key is valid.
         if (isset($config->api_settings->api_key) && $config->api_settings->api_key) {
             $mci_controller = new EE_MCI_Controller();
-            $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
+            $key_ok         = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
             if ($key_ok) {
                 $config->api_settings->mc_active = true;
                 EE_Config::instance()->update_config('addons', 'EE_Mailchimp', $config);
@@ -55,16 +67,20 @@ class EE_DMS_2_0_0_mc_options extends EE_Data_Migration_Script_Stage
         return $items_actually_migrated;
     }
 
+
+    /**
+     * @return int|void
+     */
     public function _count_records_to_migrate()
     {
-        $count_of_options_to_migrate = count($this->_mc_options_to_migrate);
-        return $count_of_options_to_migrate;
+        return count($this->_mc_options_to_migrate);
     }
+
 
     /**
      *
-     * @param type $option_name
-     * @param type $value
+     * @param string              $option_name
+     * @param string              $value
      * @param EE_Mailchimp_Config $config
      */
     private function _handle_mc_option($option_name, $value, $config)

--- a/db/migration_scripts/2_3_0_stages/EE_DMS_2_3_0_mc_options.dmsstage.php
+++ b/db/migration_scripts/2_3_0_stages/EE_DMS_2_3_0_mc_options.dmsstage.php
@@ -6,27 +6,36 @@
 class EE_DMS_2_3_0_mc_options extends EE_Data_Migration_Script_Stage
 {
 
-    protected $_mc_options_to_migrate = array(
-        'Mailchimp',
-    );
+    protected $_mc_options_to_migrate = [
+        'MailChimp',
+    ];
+
 
     public function __construct()
     {
-        $this->_pretty_name = __("MailChimp Options", "event_espresso");
-        $this->_mc_options_to_migrate = apply_filters('FHEE__EE_DMS_4_1_0_mailchimp_options__mc_options_to_migrate', $this->_mc_options_to_migrate);
+        $this->_pretty_name           = esc_html__('MailChimp Options', 'event_espresso');
+        $this->_mc_options_to_migrate = apply_filters(
+            'FHEE__EE_DMS_4_1_0_mailchimp_options__mc_options_to_migrate',
+            $this->_mc_options_to_migrate
+        );
         parent::__construct();
     }
 
+
+    /**
+     * @param int $num_items
+     * @return int
+     */
     public function _migration_step($num_items = 1)
     {
         $items_actually_migrated = 0;
-        // Get mailchimp's config.
+        // Get MailChimp's config.
         $config = EE_Config::instance()->get_config('addons', 'EE_Mailchimp', 'EE_Mailchimp_Config');
-        if (! isset($config) || ! ($config instanceof EE_Mailchimp_Config)) {
-            $config = new EE_Mailchimp_Config();
+        if (! $config instanceof EE_Mailchimp_Config) {
+            $config                                     = new EE_Mailchimp_Config();
             EE_Config::instance()->addons->EE_Mailchimp = $config;
         }
-                $success = EE_Config::instance()->set_config('addons', 'Mailchimp', 'EE_Mailchimp_Config', $config);
+        $success = EE_Config::instance()->set_config('addons', 'Mailchimp', 'EE_Mailchimp_Config', $config);
         if (! $success) {
             $this->add_error(EE_Error::get_notices());
         }
@@ -35,7 +44,7 @@ class EE_DMS_2_3_0_mc_options extends EE_Data_Migration_Script_Stage
         // Activate MC if the API Key is valid.
         if (isset($config->api_settings->api_key) && $config->api_settings->api_key) {
             $mci_controller = new EE_MCI_Controller();
-            $key_ok = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
+            $key_ok         = $mci_controller->mci_is_api_key_valid($config->api_settings->api_key);
             if ($key_ok) {
                 $config->api_settings->mc_active = true;
                 EE_Config::instance()->update_config('addons', 'Mailchimp', $config);
@@ -47,9 +56,12 @@ class EE_DMS_2_3_0_mc_options extends EE_Data_Migration_Script_Stage
         return $items_actually_migrated;
     }
 
+
+    /**
+     * @return int|void
+     */
     public function _count_records_to_migrate()
     {
-        $count_of_options_to_migrate = count($this->_mc_options_to_migrate);
-        return $count_of_options_to_migrate;
+        return count($this->_mc_options_to_migrate);
     }
 }

--- a/db/migration_scripts/EE_DMS_MailChimp_2_0_0.dms.php
+++ b/db/migration_scripts/EE_DMS_MailChimp_2_0_0.dms.php
@@ -9,10 +9,10 @@
  * instead of construction, because it only gets constructed on first page load
  * (all other times it gets resurrected from a wordpress option).
  */
-$stages = glob(ESPRESSO_MAILCHIMP_DIR . 'db/migration_scripts/2_0_0_stages/*');
-$class_to_filepath = array();
+$stages            = glob(ESPRESSO_MAILCHIMP_DIR . 'db/migration_scripts/2_0_0_stages/*');
+$class_to_filepath = [];
 foreach ($stages as $filepath) {
-    $matches = array();
+    $matches = [];
     preg_match('~2_0_0_stages/(.*).dmsstage.php~', $filepath, $matches);
     $class_to_filepath[ $matches[1] ] = $filepath;
 }
@@ -26,21 +26,28 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
 
     public function __construct()
     {
-        $this->_pretty_name = __("Data Migration to EE4 MailChimp.", "event_espresso");
-        $this->_migration_stages = array(
+        $this->_pretty_name      = esc_html__("Data Migration to EE4 MailChimp.", "event_espresso");
+        $this->_migration_stages = [
             new EE_DMS_2_0_0_mc_list_group(),
-            new EE_DMS_2_0_0_mc_options()
-        );
+            new EE_DMS_2_0_0_mc_options(),
+        ];
         parent::__construct();
     }
 
+
+    /**
+     * @param array $version_array
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function can_migrate_from_version($version_array)
     {
         global $wpdb;
         $version_string = '0';
         // Check if old MailChimp table exist.
         $old_table_exists = false;
-        $mc_table = $wpdb->prefix . "events_mailchimp_event_rel";
+        $mc_table         = $wpdb->prefix . "events_mailchimp_event_rel";
 
         // for backwards compatibility, make sure we load the activation helper (it now gets autoloaded
         // but not for older versions of EE)
@@ -48,13 +55,17 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
         if (EEH_Activation::table_exists($mc_table)) {
             $old_table_exists = true;
         }
-        $migrations_ran = EE_Data_Migration_Manager::instance()->get_data_migrations_ran();
+        $migrations_ran           = EE_Data_Migration_Manager::instance()->get_data_migrations_ran();
         $core_4_1_0_migration_ran = isset($migrations_ran['Core']) && isset($migrations_ran['Core']['4.1.0']);
-        $core_version = $version_array['Core'];
+        $core_version             = $version_array['Core'];
         if (isset($version_array['MailChimp'])) {
             $version_string = $version_array['MailChimp'];
         }
-        if (version_compare($version_string, '2.0.0', '<') && version_compare($core_version, '4.1.0', '>=') && $old_table_exists && $core_4_1_0_migration_ran) {
+        if (version_compare($version_string, '2.0.0', '<')
+            && version_compare($core_version, '4.1.0', '>=')
+            && $old_table_exists
+            && $core_4_1_0_migration_ran
+        ) {
             // Can be migrated.
             return true;
         } else {
@@ -63,18 +74,26 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
         }
     }
 
+
+    /**
+     * @return string|null
+     */
     public function pretty_name()
     {
-        return __("Data Migration to EE4 MailChimp.", "event_espresso");
+        return esc_html__("Data Migration to EE4 MailChimp.", "event_espresso");
     }
 
+
+    /**
+     * @return bool
+     */
     public function schema_changes_before_migration()
     {
         // Relies on 4.1's EEH_Activation::create_table.
         require_once(EE_HELPERS . 'EEH_Activation.helper.php');
 
         $table_name = 'esp_event_mailchimp_list_group';
-        $sql = " EMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+        $sql        = " EMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
                 EVT_ID INT UNSIGNED NOT NULL ,
                 AMC_mailchimp_list_id TEXT NOT NULL ,
                 AMC_mailchimp_group_id TEXT NOT NULL ,
@@ -82,7 +101,7 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
         $this->_table_is_new_in_this_version($table_name, $sql, 'ENGINE=InnoDB');
 
         $table_name = 'esp_event_question_mailchimp_field';
-        $sql = " QMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+        $sql        = " QMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
                 EVT_ID INT UNSIGNED NOT NULL ,
                 QST_ID TEXT NOT NULL ,
                 QMC_mailchimp_field_id TEXT NOT NULL ,
@@ -93,6 +112,7 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
         EE_Config::instance()->update_espresso_config(false, true);
         return true;
     }
+
 
     /**
      * Yes we could have cleaned up the EE3 MailChimp tables here. But just in case someone
@@ -105,6 +125,7 @@ class EE_DMS_MailChimp_2_0_0 extends EE_Data_Migration_Script_Base
     {
         return true;
     }
+
 
     public function migration_page_hooks()
     {

--- a/db/migration_scripts/EE_DMS_MailChimp_2_3_0.dms.php
+++ b/db/migration_scripts/EE_DMS_MailChimp_2_3_0.dms.php
@@ -2,6 +2,7 @@
 /**
  *  Meant to convert DBs between MailChimp 2.1.0 and MC 2.3.0.
  */
+
 /**
  * Make sure we have all the stages loaded too
  * unfortunately, this needs to be done upon INCLUSION of this file,
@@ -9,10 +10,10 @@
  * (all other times it gets resurrected from a wordpress option).
  */
 
-$stages = glob(ESPRESSO_MAILCHIMP_DIR . 'db/migration_scripts/2_3_0_stages/*');
-$class_to_filepath = array();
+$stages            = glob(ESPRESSO_MAILCHIMP_DIR . 'db/migration_scripts/2_3_0_stages/*');
+$class_to_filepath = [];
 foreach ($stages as $filepath) {
-    $matches = array();
+    $matches = [];
     preg_match('~2_3_0_stages/(.*).dmsstage.php~', $filepath, $matches);
     $class_to_filepath[ $matches[1] ] = $filepath;
 }
@@ -26,13 +27,20 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
 
     public function __construct()
     {
-        $this->_pretty_name = __("EE4 MailChimp data Migration to 2.2.0", "event_espresso");
-        $this->_migration_stages = array(
-            new EE_DMS_2_3_0_mc_options()
-        );
+        $this->_pretty_name      = esc_html__("EE4 MailChimp data Migration to 2.2.0", "event_espresso");
+        $this->_migration_stages = [
+            new EE_DMS_2_3_0_mc_options(),
+        ];
         parent::__construct();
     }
 
+
+    /**
+     * @param array $version_array
+     * @return bool
+     * @throws EE_Error
+     * @throws ReflectionException
+     */
     public function can_migrate_from_version($version_array)
     {
         $version_string = false;
@@ -48,9 +56,14 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
             $mc_old_config = EE_Config::instance()->get_config('addons', 'EE_Mailchimp', 'EE_Mailchimp_Config');
         }
 
-        if (( ( version_compare($version_string, '2.1.0', '>=') && version_compare($version_string, '2.2.0', '<') )
-            || ( version_compare($version_string, '2.2.0', '>=') && version_compare($version_string, '2.3.0', '<') && empty($mc_new_config->api_settings->api_key) ) )
-            && version_compare($core_version, '4.4.0', '>=') && isset($mc_old_config->api_settings) && ! empty($mc_old_config->api_settings->api_key)) {
+        if (((version_compare($version_string, '2.1.0', '>=') && version_compare($version_string, '2.2.0', '<'))
+             || (version_compare($version_string, '2.2.0', '>=')
+                 && version_compare($version_string, '2.3.0', '<')
+                 && empty($mc_new_config->api_settings->api_key)))
+            && version_compare($core_version, '4.4.0', '>=')
+            && isset($mc_old_config->api_settings)
+            && ! empty($mc_old_config->api_settings->api_key)
+        ) {
             // Can be migrated.
             return true;
         } elseif (! $version_string) {
@@ -62,17 +75,25 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
         }
     }
 
+
+    /**
+     * @return string|null
+     */
     public function pretty_name()
     {
-        return __("EE4 MailChimp data Migration to 2.3.0", "event_espresso");
+        return esc_html__("EE4 MailChimp data Migration to 2.3.0", "event_espresso");
     }
 
+
+    /**
+     * @return bool
+     */
     public function schema_changes_before_migration()
     {
-         require_once(EE_HELPERS . 'EEH_Activation.helper.php');
+        require_once(EE_HELPERS . 'EEH_Activation.helper.php');
 
         $table_name = 'esp_event_mailchimp_list_group';
-        $sql = " EMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+        $sql        = " EMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
                 EVT_ID INT UNSIGNED NOT NULL ,
                 AMC_mailchimp_list_id TEXT NOT NULL ,
                 AMC_mailchimp_group_id TEXT NOT NULL ,
@@ -80,7 +101,7 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
         $this->_table_should_exist_previously($table_name, $sql, 'ENGINE=InnoDB');
 
         $table_name = 'esp_event_question_mailchimp_field';
-        $sql = " QMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
+        $sql        = " QMC_ID INT UNSIGNED NOT NULL AUTO_INCREMENT ,
                 EVT_ID INT UNSIGNED NOT NULL ,
                 QST_ID TEXT NOT NULL ,
                 QMC_mailchimp_field_id TEXT NOT NULL ,
@@ -89,6 +110,7 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
 
         return true;
     }
+
 
     /**
      * Yes we could have cleaned up the EE3 MailChimp tables here. But just in case someone
@@ -105,6 +127,7 @@ class EE_DMS_MailChimp_2_3_0 extends EE_Data_Migration_Script_Base
         EE_Config::instance()->update_espresso_config(false, true);
         return true;
     }
+
 
     public function migration_page_hooks()
     {

--- a/db/models/EEM_Event_Mailchimp_List_Group.model.php
+++ b/db/models/EEM_Event_Mailchimp_List_Group.model.php
@@ -1,13 +1,11 @@
 <?php
+
 /**
  * Class  EEM_Event_Mailchimp_List_Group
  *
  * @package         Event Espresso
  * @subpackage      ee4-mailchimp
- *
- * ------------------------------------------------------------------------
  */
-
 class EEM_Event_Mailchimp_List_Group extends EEM_Base
 {
 
@@ -17,13 +15,13 @@ class EEM_Event_Mailchimp_List_Group extends EEM_Base
     protected static $_instance = null;
 
 
-
     /**
      * This function is a singleton method used to instantiate the EEM_Event_Mailchimp_List_Group object
      *
      * @access public
      * @param string $timezone
      * @return EEM_Event_Mailchimp_List_Group
+     * @throws EE_Error
      */
     public static function instance($timezone = null)
     {
@@ -38,37 +36,57 @@ class EEM_Event_Mailchimp_List_Group extends EEM_Base
     }
 
 
-
     /**
-     * @throws \EE_Error
-     * @return EEM_Event_Mailchimp_List_Group
+     * @param null $timezone
+     * @throws EE_Error
      */
     protected function __construct($timezone = null)
     {
-        $this->singular_item = __('Mailchimp List Group', 'event_espresso');
-        $this->plural_item = __('Mailchimp List Groups', 'event_espresso');
-        $this->_tables = array(
-            'Event_Mailchimp_List_Group' => new EE_Primary_Table('esp_event_mailchimp_list_group', 'EMC_ID')
-        );
-        $this->_fields = array(
-            'Event_Mailchimp_List_Group' => array(
-                'EMC_ID' => new EE_Primary_Key_Int_Field('EMC_ID', __('Field ID', 'event_espresso')),
-                'EVT_ID' => new EE_Foreign_Key_Int_Field('EVT_ID', __('Event to Mailchimp List Group Link ID', 'event_espresso'), false, 0, 'Event'),
-                'AMC_mailchimp_list_id' => new EE_Plain_Text_Field('AMC_mailchimp_list_id', __('MailChimp List ID', 'event_espresso'), false, ''),
-                'AMC_mailchimp_group_id' => new EE_Plain_Text_Field('AMC_mailchimp_group_id', __('MailChimp Group ID', 'event_espresso'), false, '')
-            )
-        );
-        $this->_model_relations = array(
-            'Event' => new EE_Belongs_To_Relation()
-        );
+        $this->singular_item    = esc_html__('MailChimp List Group', 'event_espresso');
+        $this->plural_item      = esc_html__('MailChimp List Groups', 'event_espresso');
+        $this->_tables          = [
+            'Event_Mailchimp_List_Group' => new EE_Primary_Table('esp_event_mailchimp_list_group', 'EMC_ID'),
+        ];
+        $this->_fields          = [
+            'Event_Mailchimp_List_Group' => [
+                'EMC_ID'                 => new EE_Primary_Key_Int_Field(
+                    'EMC_ID',
+                    esc_html__('Field ID', 'event_espresso')
+                ),
+                'EVT_ID'                 => new EE_Foreign_Key_Int_Field(
+                    'EVT_ID',
+                    esc_html__('Event to MailChimp List Group Link ID', 'event_espresso'),
+                    false,
+                    0,
+                    'Event'
+                ),
+                'AMC_mailchimp_list_id'  => new EE_Plain_Text_Field(
+                    'AMC_mailchimp_list_id',
+                    esc_html__('MailChimp List ID', 'event_espresso'),
+                    false,
+                    ''
+                ),
+                'AMC_mailchimp_group_id' => new EE_Plain_Text_Field(
+                    'AMC_mailchimp_group_id',
+                    esc_html__('MailChimp Group ID', 'event_espresso'),
+                    false,
+                    ''
+                ),
+            ],
+        ];
+        $this->_model_relations = [
+            'Event' => new EE_Belongs_To_Relation(),
+        ];
         parent::__construct($timezone);
     }
 
 
     /**
      * resets the model and returns it
+     *
      * @param string $timezone
      * @return EEM_Event_Mailchimp_List_Group
+     * @throws EE_Error
      */
     public static function reset($timezone = null)
     {

--- a/db/models/EEM_Question_Mailchimp_Field.model.php
+++ b/db/models/EEM_Question_Mailchimp_Field.model.php
@@ -21,7 +21,7 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
     /**
      * This function is a singleton method used to instantiate the EEM_Question_Mailchimp_Field object
      *
-     * @param null $timezone
+     * @param string|null $timezone
      * @return EEM_Question_Mailchimp_Field instance
      * @throws EE_Error
      */
@@ -41,7 +41,7 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
     /**
      * EEM_Question_Mailchimp_Field constructor.
      *
-     * @param null $timezone
+     * @param string|null $timezone
      * @throws EE_Error
      */
     protected function __construct($timezone = null)
@@ -54,7 +54,8 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
         $this->_fields          = [
             'Event_Mailchimp_List_Group' => [
                 'QMC_ID'                 => new EE_Primary_Key_Int_Field(
-                    'QMC_ID', esc_html__('MailChimp Question ID', 'event_espresso')
+                    'QMC_ID',
+                    esc_html__('MailChimp Question ID', 'event_espresso')
                 ),
                 'EVT_ID'                 => new EE_Foreign_Key_Int_Field(
                     'EVT_ID',
@@ -64,7 +65,8 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
                     'Event'
                 ),
                 'QST_ID'                 => new EE_Plain_Text_Field(
-                    'QST_ID', esc_html__('Question ID', 'event_espresso'), false
+                    'QST_ID',
+                    esc_html__('Question ID', 'event_espresso'), false
                 ),
                 'QMC_mailchimp_field_id' => new EE_Plain_Text_Field(
                     'QMC_mailchimp_field_id',
@@ -83,12 +85,13 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
     /**
      * resets the model and returns it
      *
+     * @param string|null $timezone
      * @return EEM_Question_Mailchimp_Field
      * @throws EE_Error
      */
     public static function reset($timezone = null)
     {
         self::$_instance = null;
-        return self::instance();
+        return self::instance($timezone);
     }
 }

--- a/db/models/EEM_Question_Mailchimp_Field.model.php
+++ b/db/models/EEM_Question_Mailchimp_Field.model.php
@@ -66,7 +66,8 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
                 ),
                 'QST_ID'                 => new EE_Plain_Text_Field(
                     'QST_ID',
-                    esc_html__('Question ID', 'event_espresso'), false
+                    esc_html__('Question ID', 'event_espresso'),
+                    false
                 ),
                 'QMC_mailchimp_field_id' => new EE_Plain_Text_Field(
                     'QMC_mailchimp_field_id',

--- a/db/models/EEM_Question_Mailchimp_Field.model.php
+++ b/db/models/EEM_Question_Mailchimp_Field.model.php
@@ -13,16 +13,17 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
 {
 
     /**
-     * Instance of the Attendee object
-     * @access private
+     * @var $_instance EEM_Question_Mailchimp_Field
      */
     protected static $_instance = null;
 
+
     /**
-     * This funtion is a singleton method used to instantiate the EEM_Question_Mailchimp_Field object
+     * This function is a singleton method used to instantiate the EEM_Question_Mailchimp_Field object
      *
-     * @access public
+     * @param null $timezone
      * @return EEM_Question_Mailchimp_Field instance
+     * @throws EE_Error
      */
     public static function instance($timezone = null)
     {
@@ -36,24 +37,45 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
         return self::$_instance;
     }
 
+
+    /**
+     * EEM_Question_Mailchimp_Field constructor.
+     *
+     * @param null $timezone
+     * @throws EE_Error
+     */
     protected function __construct($timezone = null)
     {
-        $this->singular_item = __('Mailchimp List Group', 'event_espresso');
-        $this->plural_item = __('Mailchimp List Groups', 'event_espresso');
-        $this->_tables = array(
-            'Event_Mailchimp_List_Group' => new EE_Primary_Table('esp_event_question_mailchimp_field', 'QMC_ID')
-        );
-        $this->_fields = array(
-            'Event_Mailchimp_List_Group' => array(
-                'QMC_ID' => new EE_Primary_Key_Int_Field('QMC_ID', __('Maichimp Q ID', 'event_espresso')),
-                'EVT_ID' => new EE_Foreign_Key_Int_Field('EVT_ID', __('Event to Mailchimp List Group Link ID', 'event_espresso'), false, 0, 'Event'),
-                'QST_ID' => new EE_Plain_Text_Field('QST_ID', __('Question ID', 'event_espresso'), false),
-                'QMC_mailchimp_field_id' => new EE_Plain_Text_Field('QMC_mailchimp_field_id', __('MailChimp Field ID', 'event_espresso'), false)
-            )
-        );
-        $this->_model_relations = array(
-            'Event' => new EE_Belongs_To_Relation()
-        );
+        $this->singular_item    = esc_html__('MailChimp List Group', 'event_espresso');
+        $this->plural_item      = esc_html__('MailChimp List Groups', 'event_espresso');
+        $this->_tables          = [
+            'Event_Mailchimp_List_Group' => new EE_Primary_Table('esp_event_question_mailchimp_field', 'QMC_ID'),
+        ];
+        $this->_fields          = [
+            'Event_Mailchimp_List_Group' => [
+                'QMC_ID'                 => new EE_Primary_Key_Int_Field(
+                    'QMC_ID', esc_html__('MailChimp Question ID', 'event_espresso')
+                ),
+                'EVT_ID'                 => new EE_Foreign_Key_Int_Field(
+                    'EVT_ID',
+                    esc_html__('Event to MailChimp List Group Link ID', 'event_espresso'),
+                    false,
+                    0,
+                    'Event'
+                ),
+                'QST_ID'                 => new EE_Plain_Text_Field(
+                    'QST_ID', esc_html__('Question ID', 'event_espresso'), false
+                ),
+                'QMC_mailchimp_field_id' => new EE_Plain_Text_Field(
+                    'QMC_mailchimp_field_id',
+                    esc_html__('MailChimp Field ID', 'event_espresso'),
+                    false
+                ),
+            ],
+        ];
+        $this->_model_relations = [
+            'Event' => new EE_Belongs_To_Relation(),
+        ];
         parent::__construct($timezone);
     }
 
@@ -62,6 +84,7 @@ class EEM_Question_Mailchimp_Field extends EEM_Base
      * resets the model and returns it
      *
      * @return EEM_Question_Mailchimp_Field
+     * @throws EE_Error
      */
     public static function reset($timezone = null)
     {

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -1,31 +1,15 @@
 <?php
 
-/*
- * Event Espresso
- *
- * Event Registration and Management Plugin for WordPress
- *
- * @ package        Event Espresso
- * @ author         Event Espresso
- * @ copyright (c)  2008-2014 Event Espresso  All Rights Reserved.
- * @ license        http://eventespresso.com/support/terms-conditions/   * see Plugin Licensing *
- * @ link           http://www.eventespresso.com
- * @ version        EE4
- *
- * ------------------------------------------------------------------------
- */
-
 use EEA_MC\MailChimp;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
 
 /**
- * Class  EE_MCI_Controller - Event Espresso MailChimp logic implementing. Intermediary between this integration and
- * the MailChimp API.
+ * Class  EE_MCI_Controller
+ * Event Espresso MailChimp logic implementing. Intermediary between this integration and the MailChimp API.
  *
  * @package         Event Espresso
  * @subpackage      ee4-mailchimp
- * ------------------------------------------------------------------------
  */
 class EE_MCI_Controller
 {
@@ -38,37 +22,32 @@ class EE_MCI_Controller
     const UPDATED_TO_API_V3 = 'updated_to_v3_of_mc_api_extra_meta_key';
 
     /**
-     * @access private
      * @var EE_Mailchimp_Config $_config
      */
-    private $_config = null;
+    private $_config;
 
     /**
-     * @access private
      * @var string $_api_key
      */
-    private $_api_key = null;
+    private $_api_key;
 
     /**
      * Error details.
      *
-     * @access private
      * @var array $mcapi_error
      */
-    private $mcapi_error = array();
+    private $mcapi_error = [];
 
     /**
      * MailChimp API Object.
      *
-     * @access private
-     * @var \EEA_MC\MailChimp $MailChimp
+     * @var MailChimp $MailChimp
      */
-    private $MailChimp = null;
+    private $MailChimp;
 
     /**
      * The selected List ID.
      *
-     * @access private
      * @var int $list_id
      */
     private $list_id = 0;
@@ -76,7 +55,6 @@ class EE_MCI_Controller
     /**
      * The selected interest group ID.
      *
-     * @access private
      * @var int $category_id
      */
     private $category_id = 0;
@@ -86,7 +64,7 @@ class EE_MCI_Controller
      * Class constructor
      *
      * @param string $api_key
-     * @return EE_MCI_Controller
+     * @throws EE_Error
      */
     public function __construct($api_key = '')
     {
@@ -95,7 +73,7 @@ class EE_MCI_Controller
         $this->_config = EED_Mailchimp::instance()->config();
 
         // Verify API key.
-        $api_key = ! empty($api_key) ? $api_key : $this->_config->api_settings->api_key;
+        $api_key        = ! empty($api_key) ? $api_key : $this->_config->api_settings->api_key;
         $this->_api_key = $this->mci_is_api_key_valid($api_key);
     }
 
@@ -103,12 +81,12 @@ class EE_MCI_Controller
     /**
      * Validate the MailChimp API key. If key not provided then the one that is saved in the settings will be checked.
      *
-     * @access public
      * @param string $api_key MailChimp API Key.
      * @param array  $call_reply
      * @return bool  Is Key valid or not
+     * @throws EE_Error
      */
-    public function mci_is_api_key_valid($api_key = null, $call_reply = array())
+    public function mci_is_api_key_valid($api_key = null, $call_reply = [])
     {
         do_action('AHEE__EE_MCI_Controller__mci_is_api_key_valid__start');
         // Make sure API key only has one '-'
@@ -122,11 +100,11 @@ class EE_MCI_Controller
         // Check if key is live/acceptable by API.
         try {
             $this->MailChimp = new MailChimp($api_key);
-            $parameters = apply_filters(
+            $parameters      = apply_filters(
                 'AHEE__EE_MCI_Controller__mci_is_api_key_valid__parameters',
-                array('fields' => 'account_id,account_name,email,username')
+                ['fields' => 'account_id,account_name,email,username']
             );
-            $reply = $this->MailChimp->get('', $parameters);
+            $reply           = $this->MailChimp->get('', $parameters);
         } catch (Exception $e) {
             $this->set_error($e);
             do_action('AHEE__EE_MCI_Controller__mci_is_api_key_valid__api_key_error');
@@ -149,36 +127,41 @@ class EE_MCI_Controller
     /**
      * Retrieve EE_Registration and EE_Transaction objects from incoming data.
      *
-     * @access                          protected
      * @param EED_Single_Page_Checkout || EE_SPCO_Reg_Step_Attendee_Information $spco_obj
      * @return array ( EE_Transaction, EE_Registration[] )
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     protected function _mci_get_registrations($spco_obj)
     {
-        $spco_registrations = array();
-        $spco_transaction = false;
+        $spco_registrations = [];
+        $spco_transaction   = false;
         // what kind of SPCO object did we receive?
         if ($spco_obj instanceof EE_SPCO_Reg_Step_Attendee_Information) {
             // for EE versions > 4.6
-            if ($spco_obj->checkout instanceof EE_Checkout && $spco_obj->checkout->transaction instanceof EE_Transaction) {
+            if ($spco_obj->checkout instanceof EE_Checkout
+                && $spco_obj->checkout->transaction
+                   instanceof
+                   EE_Transaction
+            ) {
                 $spco_registrations = $spco_obj->checkout->transaction->registrations(
                     $spco_obj->checkout->reg_cache_where_params,
                     true
                 );
-                $spco_transaction = $spco_obj->checkout->transaction;
+                $spco_transaction   = $spco_obj->checkout->transaction;
             }
         } elseif ($spco_obj instanceof EED_Single_Page_Checkout) {
             $transaction = EE_Registry::instance()->SSN->get_session_data('transaction');
             // for EE versions < 4.6
             if ($transaction instanceof EE_Transaction) {
-                $spco_registrations = $transaction->registrations(array(), true);
-                $spco_transaction = $transaction;
+                $spco_registrations = $transaction->registrations([], true);
+                $spco_transaction   = $transaction;
             }
         } elseif ($spco_obj instanceof EE_Checkout) {
             $spco_registrations = $spco_obj->transaction->registrations($spco_obj->reg_cache_where_params, true);
-            $spco_transaction = $spco_obj;
+            $spco_transaction   = $spco_obj;
         }
-        return array('registrations' => $spco_registrations, 'transaction' => $spco_transaction);
+        return ['registrations' => $spco_registrations, 'transaction' => $spco_transaction];
     }
 
 
@@ -188,30 +171,31 @@ class EE_MCI_Controller
      * update_txn_based_on_payment__successful) the:
      * $spc_obj could be an instanceof: EE_SPCO_Reg_Step_Attendee_Information, EED_Single_Page_Checkout or EE_Checkout.
      *
-     * @param EED_Single_Page_Checkout/EE_SPCO_Reg_Step_Attendee_Information/EE_Checkout $spc_obj  Single Page Checkout
-     *                                                                                             (SPCO) Object.
-     * @param array/EE_Payment $valid_data  Valid data from the Attendee Information Registration form / EE_Payment.
+     * @param $spc_obj
+     * @param $valid_data
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_submit_to_mailchimp($spc_obj, $valid_data)
     {
         // Do not submit if the key is not valid or there is no valid submit data.
         if ($this->MailChimp instanceof EEA_MC\MailChimp && ! empty($spc_obj)) {
-            $spco_data = $this->_mci_get_registrations($spc_obj);
-            $registrations = $spco_data['registrations'];
+            $spco_data        = $this->_mci_get_registrations($spc_obj);
+            $registrations    = $spco_data['registrations'];
             $spco_transaction = $spco_data['transaction'];
 
             do_action('AHEE__EE_MCI_Controller__mci_submit_to_mailchimp__start', $spco_transaction, $registrations);
 
-            $registered_attendees = array();
+            $registered_attendees = [];
             // now loop through registrations to get the related attendee objects
             if (! empty($registrations)) {
                 foreach ($registrations as $registration) {
                     if ($registration instanceof EE_Registration) {
-                        $EVT_ID = $registration->event_ID();
+                        $EVT_ID     = $registration->event_ID();
                         $event_list = $this->mci_event_list($EVT_ID);
                         // If no list selected for this event then skip the subscription.
-                        if (empty($event_list) || (! empty($event_list) && intval($event_list) === -1)) {
+                        if (empty($event_list) || intval($event_list) === -1) {
                             continue;
                         }
 
@@ -219,33 +203,36 @@ class EE_MCI_Controller
                         $this->is_db_data_api_compatible($EVT_ID, $event_list);
 
                         $need_reg_status = $reg_approved = false;
-                        /** @type EE_Mailchimp_Config $mc_config */
                         $mc_config = EED_Mailchimp::get_config();
                         if ($mc_config->api_settings->submit_to_mc_when === 'reg-step-approved') {
                             $need_reg_status = true;
-                            $reg_status = $registration->status_ID();
+                            $reg_status      = $registration->status_ID();
                             if ($reg_status === EEM_Registration::status_id_approved) {
                                 $reg_approved = true;
                             }
                         }
                         // Pull the EE_Attendee object for the registration
                         $attendee = $registration->attendee();
-                        // If no EE_Attendee object, skip the subcribe call to MailChimp.
+                        // If no EE_Attendee object, skip the subscribe call to MailChimp.
                         if (! $attendee instanceof EE_Attendee) {
                             continue;
                         }
                         $att_email = $attendee->email();
                         if (! in_array(
-                            $att_email,
-                            $registered_attendees
-                        ) && (! $need_reg_status || $need_reg_status && $reg_approved)) {
-                            $opt_in = isset($this->_config->api_settings->skip_double_optin)
-                                ? $this->_config->api_settings->skip_double_optin : true;
-                            $emails_type = isset($this->_config->api_settings->emails_type)
-                                ? $this->_config->api_settings->emails_type : 'text';
-                            $subscribe_args = array(
+                                $att_email,
+                                $registered_attendees
+                            )
+                            && (! $need_reg_status || $reg_approved)
+                        ) {
+                            $opt_in         = isset($this->_config->api_settings->skip_double_optin)
+                                ? $this->_config->api_settings->skip_double_optin
+                                : true;
+                            $emails_type    = isset($this->_config->api_settings->emails_type)
+                                ? $this->_config->api_settings->emails_type
+                                : 'text';
+                            $subscribe_args = [
                                 'email_address' => $att_email,
-                            );
+                            ];
                             // Group vars
                             $subscribe_args = $this->_add_event_group_vars_to_subscribe_args($EVT_ID, $subscribe_args);
                             // Question fields
@@ -271,10 +258,10 @@ class EE_MCI_Controller
 
                             // Verify merge_fields and interests aren't empty, and if they are they need to be stdClasses so that they become JSON objects still
                             if (empty($subscribe_args['merge_fields'])) {
-                                $subscribe_args['merge_fields'] = new \stdClass();
+                                $subscribe_args['merge_fields'] = new stdClass();
                             }
                             if (empty($subscribe_args['interests'])) {
-                                $subscribe_args['interests'] = new \stdClass();
+                                $subscribe_args['interests'] = new stdClass();
                             }
                             try {
                                 // Get member info if exists.
@@ -282,12 +269,14 @@ class EE_MCI_Controller
                                     '/lists/' . $event_list . '/members/' . $this->MailChimp->subscriberHash(
                                         $att_email
                                     ),
-                                    array('fields' => 'id,email_address,status')
+                                    ['fields' => 'id,email_address,status']
                                 );
-                                if (isset($member_subscribed['email_address']) && isset($member_subscribed['status']) && ! preg_match(
-                                    '/^(4|5)\d{2}$/',
-                                    $member_subscribed['status']
-                                )) {
+                                if (isset($member_subscribed['email_address']) && isset($member_subscribed['status'])
+                                    && ! preg_match(
+                                        '/^(4|5)\d{2}$/',
+                                        $member_subscribed['status']
+                                    )
+                                ) {
                                     $subscribe_args['status'] = $member_subscribed['status'];
                                 }
                                 // Send opt-in emails ?
@@ -310,7 +299,7 @@ class EE_MCI_Controller
                                     $this->set_error($put_member);
                                     $errors = '';
                                     if (isset($put_member['errors']) && is_array($put_member['errors'])) {
-                                        $errs = array();
+                                        $errs = [];
                                         foreach ($put_member['errors'] as $err) {
                                             $err_msg = isset($err['field'])
                                                 ? sprintf(
@@ -324,14 +313,14 @@ class EE_MCI_Controller
                                             $err_msg .= isset($err['message'])
                                                 ? $err['message']
                                                 : esc_html__('No error mentioned', 'event_espresso');
-                                            $errs[] = $err_msg;
+                                            $errs[]  = $err_msg;
                                         }
                                         $errors = implode(', ', $errs);
                                     }
-                                    $evt_obj = $registration->event();
+                                    $evt_obj       = $registration->event();
                                     $evt_permalink = ($evt_obj instanceof EE_Event) ? $evt_obj->get_permalink() : '#';
-                                    $notice_msg = sprintf(
-                                        __(
+                                    $notice_msg    = sprintf(
+                                        esc_html__(
                                             'This registration could not be subscribed to a MailChimp List with ID: %1$s. There were errors regarding the following: %2$s. 
                                             Any mandatory or multi-choice fields that are in this MailChimp list require to be paired with Event questions (in this case %3$s event) that correspond by type and possibly by having the same answer values. 
                                             If you have further problems please contact support.',
@@ -349,7 +338,6 @@ class EE_MCI_Controller
                                     );
                                 }
                             } catch (Exception $e) {
-                                $member_subscribed = false;
                                 $this->set_error($e);
                             }
                             $registered_attendees[] = $att_email;
@@ -364,12 +352,13 @@ class EE_MCI_Controller
     /**
      * _add_event_group_vars_to_subscribe_args
      *
-     * @access public
      * @param int   $EVT_ID
      * @param array $subscribe_args
      * @return array|StdClass
+     * @throws EE_Error
+     * @throws ReflectionException
      */
-    protected function _add_event_group_vars_to_subscribe_args($EVT_ID = 0, $subscribe_args = array())
+    protected function _add_event_group_vars_to_subscribe_args($EVT_ID = 0, $subscribe_args = [])
     {
         $event_groups = $this->mci_event_list_group($EVT_ID);
         if (! empty($event_groups)) {
@@ -388,25 +377,24 @@ class EE_MCI_Controller
     /**
      * _process_event_group_subscribe_args
      *
-     * @access public
      * @param string $event_group
      * @param array  $subscribe_args
      * @return array  List of MailChimp lists.
      */
-    protected function _process_event_group_subscribe_args($event_group = '', $subscribe_args = array())
+    protected function _process_event_group_subscribe_args($event_group = '', $subscribe_args = [])
     {
         // Initialise the interests array if it hasn't been already.
         if (! isset($subscribe_args['interests']) || empty($subscribe_args['interests'])) {
-            $subscribe_args['interests'] = array();
+            $subscribe_args['interests'] = [];
         }
 
         $grouping = explode('-', $event_group);
-        
+
         // Add selected interests to the subscribe_args.
         if (isset($grouping[3]) && $grouping[3] === 'true') {
             $subscribe_args['interests'][ $grouping[0] ] = true;
         }
-        
+
         return $subscribe_args;
     }
 
@@ -414,31 +402,32 @@ class EE_MCI_Controller
     /**
      * _add_registration_question_answers_to_subscribe_args
      *
-     * @access public
      * @param EE_Registration $registration
      * @param int             $EVT_ID
      * @param array           $subscribe_args
-     * @throws InvalidArgumentException
+     * @return array
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
      * @throws EE_Error
-     * @return array
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     protected function _add_registration_question_answers_to_subscribe_args(
         EE_Registration $registration,
         $EVT_ID = 0,
-        $subscribe_args = array()
+        $subscribe_args = []
     ) {
         if (! is_array($subscribe_args)) {
             throw new EE_Error(__('The MailChimp Subscriber arguments array is malformed!', 'event_espresso'));
         }
         if (! isset($subscribe_args['merge_fields'])) {
-            $subscribe_args['merge_fields'] = array();
+            $subscribe_args['merge_fields'] = [];
         }
 
         $mc_field_to_ee_q_map = $this->mci_event_list_question_fields($EVT_ID);
         foreach ($mc_field_to_ee_q_map as $mc_field_code => $qst_id) {
-            $value = EEM_Answer::instance()->get_answer_value_to_question($registration, $qst_id, true);
+            $value                                            =
+                EEM_Answer::instance()->get_answer_value_to_question($registration, $qst_id, true);
             $subscribe_args['merge_fields'][ $mc_field_code ] = $value;
         }
         return $subscribe_args;
@@ -448,15 +437,15 @@ class EE_MCI_Controller
     /**
      * Retrieve all of the lists defined for your user account.
      *
-     * @access public
      * @return array  List of MailChimp lists.
+     * @throws EE_Error
      */
     public function mci_get_users_lists()
     {
         do_action('AHEE__EE_MCI_Controller__mci_get_users_lists__start');
         $parameters = apply_filters(
             'FHEE__EE_MCI_Controller__mci_get_users_lists__list_params',
-            array('fields' => 'lists.id,lists.name', 'count' => 100, 'apikey' => $this->_api_key),
+            ['fields' => 'lists.id,lists.name', 'count' => 100, 'apikey' => $this->_api_key],
             $this
         );
 
@@ -464,7 +453,7 @@ class EE_MCI_Controller
             $reply = $this->MailChimp->get('lists', $parameters);
         } catch (Exception $e) {
             $this->set_error($e);
-            return array();
+            return [];
         }
 
         if ($this->MailChimp->success() && isset($reply['lists'])) {
@@ -474,7 +463,7 @@ class EE_MCI_Controller
             if (! $this->MailChimp->success()) {
                 $this->set_error($reply);
             }
-            return array();
+            return [];
         }
     }
 
@@ -482,54 +471,68 @@ class EE_MCI_Controller
     /**
      * Get the list of Interest Categories for a given list.
      *
-     * @access public
      * @param string $list_id The ID of the List.
      * @return array  List of MailChimp groups of selected List.
+     * @throws EE_Error
      */
     public function mci_get_users_groups($list_id)
     {
         do_action('AHEE__EE_MCI_Controller__mci_get_users_groups__start');
         $parameters = apply_filters(
             'AHEE__EE_MCI_Controller__mci_get_users_groups__parameters',
-            array('exclude_fields' => '_links,categories._links', 'count' => 50)
+            ['exclude_fields' => '_links,categories._links', 'count' => 50]
         );
 
         if ($list_id == null) {
             $list_id = $this->list_id;
         }
-
-        try {
-            $reply = $this->MailChimp->get('lists/' . $list_id . '/interest-categories', $parameters);
-        } catch (Exception $e) {
-            $this->set_error($e);
-            return array();
-        }
-        if ($this->MailChimp->success() && isset($reply['categories'])) {
-            return (array) $reply['categories'];
-        } else {
-            // The list of requested items might just be empty or there might be an error response.
-            if (! $this->MailChimp->success()) {
-                $this->set_error($reply);
-            }
-            return array();
-        }
+        return $this->get_list('lists/' . $list_id . '/interest-categories', $parameters, 'categories');
     }
 
 
     /**
      * Get the list of interests for a specific MailChimp list.
      *
-     * @access public
+     * @param string $method
+     * @param array  $parameters
+     * @param string $key
+     * @return array MailChimp List.
+     * @throws EE_Error
+     */
+    private function get_list($method, array $parameters, $key)
+    {
+
+        try {
+            $reply = $this->MailChimp->get($method, $parameters);
+        } catch (Exception $e) {
+            $this->set_error($e);
+            return [];
+        }
+        if ($this->MailChimp->success() && isset($reply[ $key])) {
+            return (array) $reply[ $key];
+        }
+        // The list of requested items might just be empty or there might be an error response.
+        if (! $this->MailChimp->success()) {
+            $this->set_error($reply);
+        }
+        return [];
+    }
+
+
+    /**
+     * Get the list of interests for a specific MailChimp list.
+     *
      * @param string $list_id     The ID of the List.
      * @param string $category_id The ID of the interest category.
      * @return array  List of MailChimp interests of selected List.
+     * @throws EE_Error
      */
     public function mci_get_interests($list_id, $category_id)
     {
         do_action('AHEE__EE_MCI_Controller__mci_get_interests__start');
         $parameters = apply_filters(
             'AHEE__EE_MCI_Controller__mci_get_interests__parameters',
-            array('fields' => 'interests', 'exclude_fields' => 'interests._links', 'count' => 100)
+            ['fields' => 'interests', 'exclude_fields' => 'interests._links', 'count' => 100]
         );
 
         if ($list_id == null) {
@@ -538,41 +541,27 @@ class EE_MCI_Controller
         if ($category_id == null) {
             $category_id = $this->category_id;
         }
-
-        try {
-            $reply = $this->MailChimp->get(
-                'lists/' . $list_id . '/interest-categories/' . $category_id . '/interests',
-                $parameters
-            );
-        } catch (Exception $e) {
-            $this->set_error($e);
-            return array();
-        }
-        if ($this->MailChimp->success() && isset($reply['interests'])) {
-            return (array) $reply['interests'];
-        } else {
-            // The list of requested items might just be empty or there might be an error response.
-            if (! $this->MailChimp->success()) {
-                $this->set_error($reply);
-            }
-            return array();
-        }
+        return $this->get_list(
+            'lists/' . $list_id . '/interest-categories/' . $category_id . '/interests',
+            $parameters,
+            'interests'
+        );
     }
 
 
     /**
      * Get the list of merge tags for a given list.
      *
-     * @access public
      * @param string $list_id The ID of the List.
      * @return array   MailChimp List of merge tags.
+     * @throws EE_Error
      */
     public function mci_get_list_merge_vars($list_id)
     {
         do_action('AHEE__EE_MCI_Controller__mci_get_list_merge_vars__start');
         $parameters = apply_filters(
             'AHEE__EE_MCI_Controller__mci_get_list_merge_vars__parameters',
-            array('fields' => 'merge_fields', 'exclude_fields' => '_links,merge_fields._links', 'count' => 50)
+            ['fields' => 'merge_fields', 'exclude_fields' => '_links,merge_fields._links', 'count' => 50]
         );
         if ($list_id == null) {
             $list_id = $this->list_id;
@@ -582,7 +571,7 @@ class EE_MCI_Controller
             $reply = $this->MailChimp->get('lists/' . $list_id . '/merge-fields', $parameters);
         } catch (Exception $e) {
             $this->set_error($e);
-            return array();
+            return [];
         }
         if ($this->MailChimp->success() && isset($reply['merge_fields'])) {
             return (array) $reply['merge_fields'];
@@ -591,7 +580,7 @@ class EE_MCI_Controller
             if (! $this->MailChimp->success()) {
                 $this->set_error($reply);
             }
-            return array();
+            return [];
         }
     }
 
@@ -599,9 +588,10 @@ class EE_MCI_Controller
     /**
      * Set up 'MailChimp List Integration' meta-box section contents.
      *
-     * @access public
      * @param WP_Post $event The post object.
      * @return string
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_set_metabox_contents($event)
     {
@@ -610,7 +600,7 @@ class EE_MCI_Controller
             // Check if the DB data can be safely used with current API.
             $this->is_db_data_api_compatible($event->ID);
             // Get saved list for this event (if there's one)
-            $this->list_id = $this->mci_event_list($event->ID);
+            $this->list_id     = $this->mci_event_list($event->ID);
             $this->category_id = $this->mci_event_list_group($event->ID);
 
             $metabox_obj = new EE_MC_Metabox_Form($this, $event->ID, $this->list_id, $this->category_id);
@@ -642,14 +632,15 @@ class EE_MCI_Controller
     /**
      * Save the contents of 'MailChimp List Integration' meta-box.
      *
-     * @access public
      * @param int $event_id An ID on the Event.
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_save_metabox_contents($event_id)
     {
         // Clear MailChimp data on the current event and then save the new data.
-        $lg_exists = EEM_Event_Mailchimp_List_Group::instance()->get_all(array(array('EVT_ID' => $event_id)));
+        $lg_exists = EEM_Event_Mailchimp_List_Group::instance()->get_all([['EVT_ID' => $event_id]]);
         if (! empty($lg_exists)) {
             foreach ($lg_exists as $list_group) {
                 $list_group->delete();
@@ -657,22 +648,28 @@ class EE_MCI_Controller
         }
 
         // Lists and Groups
-        $list_id = $_POST['ee_mailchimp_lists'];
-        if (! empty($_POST['ee_mailchimp_groups']) && ! empty($_POST['ee_mc_list_all_interests'])) {
-            $all_interests = $_POST['ee_mc_list_all_interests'];
-            $group_ids = array();
+        $list_id = sanitize_text_field($_POST['ee_mailchimp_lists']);
+        $mailchimp_groups = array_key_exists('ee_mailchimp_groups', $_POST)
+            ? $_POST['ee_mailchimp_groups']
+            : [];
+        $all_interests = array_key_exists('ee_mc_list_all_interests', $_POST)
+            ? $_POST['ee_mc_list_all_interests']
+            : [];
+        if (! empty($mailchimp_groups) && ! empty($all_interests)) {
+            $group_ids     = [];
             // Multidimensional array ? Straighten it up.
-            foreach ($_POST['ee_mailchimp_groups'] as $g_id) {
+            foreach ($mailchimp_groups as $g_id) {
                 if (is_array($g_id)) {
                     foreach ($g_id as $l2g_id) {
-                        $group_ids[] = $l2g_id;
+                        $group_ids[] = sanitize_text_field($l2g_id);
                     }
                 } else {
-                    $group_ids[] = $g_id;
+                    $group_ids[] = sanitize_text_field($g_id);
                 }
             }
             // We need to save the list of all interests for the current MC List.
             foreach ($all_interests as $interest) {
+                $interest = sanitize_key($interest);
                 // Mark what lists were selected and not.
                 if (in_array($interest, $group_ids)) {
                     $interest .= '-true';
@@ -680,11 +677,11 @@ class EE_MCI_Controller
                     $interest .= '-false';
                 }
                 $new_list_group = EE_Event_Mailchimp_List_Group::new_instance(
-                    array(
+                    [
                         'EVT_ID'                 => $event_id,
                         'AMC_mailchimp_list_id'  => $list_id,
                         'AMC_mailchimp_group_id' => $interest,
-                    )
+                    ]
                 );
                 $new_list_group->save();
             }
@@ -696,63 +693,67 @@ class EE_MCI_Controller
             }
         } else {
             $new_list_group = EE_Event_Mailchimp_List_Group::new_instance(
-                array(
+                [
                     'EVT_ID'                 => $event_id,
                     'AMC_mailchimp_list_id'  => $list_id,
                     'AMC_mailchimp_group_id' => -1,
-                )
+                ]
             );
             $new_list_group->save();
         }
 
-        $qf_exists = EEM_Question_Mailchimp_Field::instance()->get_all(array(array('EVT_ID' => $event_id)));
+        $qf_exists = EEM_Question_Mailchimp_Field::instance()->get_all([['EVT_ID' => $event_id]]);
+
+        $question_fields_list = array_key_exists('ee_mailchimp_qfields', $_POST)
+            ? $_POST['ee_mailchimp_qfields']
+            : [];
         // Question Fields
-        if (isset($_POST['ee_mailchimp_qfields']) && is_array(
-            $_POST['ee_mailchimp_qfields']
-        ) && ! empty($_POST['ee_mailchimp_qfields'])) {
-            $qfields_list = $_POST['ee_mailchimp_qfields'];
-            $list_form_rel = array();
-            foreach ($qfields_list as $mc_question) {
-                $encoded = base64_encode($mc_question);
+        if (is_array($question_fields_list) && ! empty($question_fields_list)) {
+            foreach ($question_fields_list as $mc_question_id) {
+                $encoded = base64_encode($mc_question_id);
                 if (isset($_POST[ $encoded ]) && $_POST[ $encoded ] != '-1') {
                     $ev_question = $_POST[ $encoded ];
-                    $list_form_rel[ $mc_question ] = $ev_question;
-
                     $q_found = false;
                     // Update already present Q fields.
                     foreach ($qf_exists as $question_field) {
-                        $mc_field = $question_field instanceof EE_Question_Mailchimp_Field ? $question_field->mc_field()
+                        $mc_field = $question_field instanceof EE_Question_Mailchimp_Field
+                            ? $question_field->mc_field()
                             : '';
-                        if ($mc_field == $mc_question) {
+                        if ($mc_field == $mc_question_id) {
                             EEM_Question_Mailchimp_Field::instance()->update(
-                                array('QST_ID' => $ev_question),
-                                array(array('EVT_ID' => $event_id, 'QMC_mailchimp_field_id' => $mc_question))
+                                ['QST_ID' => $ev_question],
+                                [
+                                    [
+                                        'EVT_ID' => $event_id,
+                                        'QMC_mailchimp_field_id' => $mc_question_id
+                                    ]
+                                ]
                             );
                             $q_found = true;
                         }
                     }
                     // Add Q field if was not present.
                     if (! $q_found) {
-                        $new_qfield = EE_Question_Mailchimp_Field::new_instance(
-                            array(
+                        $new_question_field = EE_Question_Mailchimp_Field::new_instance(
+                            [
                                 'EVT_ID'                 => $event_id,
                                 'QST_ID'                 => $ev_question,
-                                'QMC_mailchimp_field_id' => $mc_question,
-                            )
+                                'QMC_mailchimp_field_id' => $mc_question_id,
+                            ]
                         );
-                        $new_qfield->save();
+                        $new_question_field->save();
                     }
                 } else {
-                    $mcqe = EEM_Question_Mailchimp_Field::instance()->get_one(
-                        array(
-                            array(
+                    $mc_question = EEM_Question_Mailchimp_Field::instance()->get_one(
+                        [
+                            [
                                 'EVT_ID'                 => $event_id,
-                                'QMC_mailchimp_field_id' => $mc_question,
-                            ),
-                        )
+                                'QMC_mailchimp_field_id' => $mc_question_id,
+                            ],
+                        ]
                     );
-                    if ($mcqe != null) {
-                        $mcqe->delete();
+                    if ($mc_question != null) {
+                        $mc_question->delete();
                     }
                 }
             }
@@ -763,9 +764,9 @@ class EE_MCI_Controller
     /**
      * Display the MailChimp user Lists for given event.
      *
-     * @access public
      * @param int $list_id
      * @return string (HTML)
+     * @throws EE_Error
      */
     public function mci_list_mailchimp_lists($list_id = 0)
     {
@@ -775,20 +776,19 @@ class EE_MCI_Controller
             // Load the lists form.
             $lists_obj = new EE_MC_Lists_Form($this, $list_id);
             return $lists_obj->get_html_and_js();
-        } else {
-            // Something is wrong with the API so we return nothing.
-            return new EE_Form_Section_HTML('');
         }
+        // Something is wrong with the API so we return nothing.
+        return new EE_Form_Section_HTML('');
     }
 
 
     /**
      * Display MailChimp interest Categories for the given event (depending on the selected List).
      *
-     * @access public
      * @param int $event_id The ID of the Event.
      * @param int $list_id
      * @return string (HTML)
+     * @throws EE_Error
      */
     public function mci_list_mailchimp_groups($event_id = 0, $list_id = 0)
     {
@@ -798,20 +798,19 @@ class EE_MCI_Controller
             // Load the interests form.
             $interest_categories_obj = new EE_MC_Interest_Categories_Form($this, $event_id, $list_id);
             return $interest_categories_obj->get_html_and_js();
-        } else {
-            // Something is wrong with the API so we return nothing.
-            return new EE_Form_Section_HTML('');
         }
+        // Something is wrong with the API so we return nothing.
+        return new EE_Form_Section_HTML('');
     }
 
 
     /**
      * Display MailChimp merge Fields of the given event (depending on the selected list).
      *
-     * @access public
      * @param int $event_id The ID of the Event.
      * @param int $list_id
      * @return string (HTML)
+     * @throws EE_Error
      */
     public function mci_list_mailchimp_fields($event_id = 0, $list_id = 0)
     {
@@ -826,34 +825,34 @@ class EE_MCI_Controller
      * Get the list of question groups (EQG_primary) of the Event. If there are non (because it's a new event)
      * then at least return the main question group
      *
-     * @access public
      * @param string $event_id The ID of the Event.
      * @return array  List of all primary QGs fn the Event.
+     * @throws EE_Error
      */
     public function mci_get_event_question_groups($event_id)
     {
-        $question_groups = array();
+        $question_groups = [];
         // only bother querying for question groups related to the evnent if the event exists
         if ($event_id) {
             $question_groups = EEM_Question_Group::instance()->get_all(
-                array(
-                    array(
+                [
+                    [
                         'Event.EVT_ID'                     => $event_id,
                         'Event_Question_Group.EQG_primary' => true,
-                    ),
-                    'order_by' => array('QSG_order' => 'ASC'),
-                )
+                    ],
+                    'order_by' => ['QSG_order' => 'ASC'],
+                ]
             );
         }
         // if this is a new event, or somehow we didn't find any groups,
         // then at least grab the primary question group
         if (empty($question_groups)) {
             $question_groups = EEM_Question_Group::instance()->get_all(
-                array(
-                    array(
+                [
+                    [
                         'QSG_system' => EEM_Question_Group::system_personal,
-                    ),
-                )
+                    ],
+                ]
             );
         }
         return $question_groups;
@@ -863,23 +862,24 @@ class EE_MCI_Controller
     /**
      * Get all questions of all primary question groups of the Event.
      *
-     * @access public
      * @param string $event_id The ID of the Event.
      * @return array  List of all primary Questions of the Event.
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_get_event_all_questions($event_id)
     {
-        $questions = array();
+        $questions       = [];
         $question_groups = $this->mci_get_event_question_groups($event_id);
         if (is_array($question_groups) && ! empty($question_groups)) {
             foreach ($question_groups as $QG_list) {
                 if ($QG_list instanceof EE_Question_Group) {
                     foreach ($QG_list->questions() as $question) {
-                        $qst = array(
+                        $qst = [
                             'QST_name'   => $question->get('QST_display_text'),
                             'QST_ID'     => $question->get('QST_ID'),
                             'QST_system' => $question->get('QST_system'),
-                        );
+                        ];
                         if (! in_array($qst, $questions)) {
                             $questions[ $question->ID() ] = $qst;
                         }
@@ -888,7 +888,7 @@ class EE_MCI_Controller
             }
             return $questions;
         } else {
-            return array();
+            return [];
         }
     }
 
@@ -896,18 +896,19 @@ class EE_MCI_Controller
     /**
      * Get MailChimp Event list
      *
-     * @access public
      * @param int $EVT_ID The ID of the Event.
      * @return EE_Event_Mailchimp_List_Group
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_event_list($EVT_ID)
     {
         EE_Registry::instance()->load_model('Event_Mailchimp_List_Group');
         $event_list = EEM_Event_Mailchimp_List_Group::instance()->get_all(
-            array(
-                array('EVT_ID' => $EVT_ID),
+            [
+                ['EVT_ID' => $EVT_ID],
                 'limit' => 1,
-            )
+            ]
         );
         $event_list = reset($event_list);
         return $event_list instanceof EE_Event_Mailchimp_List_Group ? $event_list->mc_list() : null;
@@ -917,18 +918,20 @@ class EE_MCI_Controller
     /**
      * Get MailChimp Event list group
      *
-     * @access public
      * @param int $EVT_ID The ID of the Event.
      * @return EE_Event_Mailchimp_List_Group[]
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_event_list_group($EVT_ID)
     {
         EE_Registry::instance()->load_model('Event_Mailchimp_List_Group');
-        $mc_list_groups = EEM_Event_Mailchimp_List_Group::instance()->get_all(array(array('EVT_ID' => $EVT_ID)));
-        $event_list_groups = array();
+        $mc_list_groups    = EEM_Event_Mailchimp_List_Group::instance()->get_all([['EVT_ID' => $EVT_ID]]);
+        $event_list_groups = [];
         foreach ($mc_list_groups as $mc_list_group) {
             if ($mc_list_group instanceof EE_Event_Mailchimp_List_Group
-                && $mc_list_group->mc_group() !== '-1') {
+                && $mc_list_group->mc_group() !== '-1'
+            ) {
                 $event_list_groups[] = $mc_list_group->mc_group();
             }
         }
@@ -939,13 +942,14 @@ class EE_MCI_Controller
     /**
      * Get a list of selected Interests.
      *
-     * @access public
      * @param int $EVT_ID The ID of the Event.
      * @return EE_Event_Mailchimp_List_Group[]
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_event_selected_interests($EVT_ID)
     {
-        $selected = array();
+        $selected      = [];
         $all_interests = $this->mci_event_list_group($EVT_ID);
         foreach ($all_interests as $interest) {
             if (strpos($interest, '-true') !== false) {
@@ -959,15 +963,16 @@ class EE_MCI_Controller
     /**
      * Get MailChimp Event list question fields
      *
-     * @access public
      * @param int $EVT_ID The ID of the Event.
      * @return array
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_event_list_question_fields($EVT_ID)
     {
         EE_Registry::instance()->load_model('Question_Mailchimp_Field');
-        $mc_question_fields = EEM_Question_Mailchimp_Field::instance()->get_all(array(array('EVT_ID' => $EVT_ID)));
-        $event_list_question_fields = array();
+        $mc_question_fields         = EEM_Question_Mailchimp_Field::instance()->get_all([['EVT_ID' => $EVT_ID]]);
+        $event_list_question_fields = [];
         foreach ($mc_question_fields as $mc_question_field) {
             if ($mc_question_field instanceof EE_Question_Mailchimp_Field) {
                 $event_list_question_fields[ $mc_question_field->mc_field() ] = $mc_question_field->mc_event_question();
@@ -980,28 +985,30 @@ class EE_MCI_Controller
     /**
      * Get MailChimp list or groups or question fields relationships, set for given event.
      *
-     * @access public
      * @param int $EVT_ID    The ID of the Event.
      * @return array/string  Id of a group/list or an array of 'List fields - Event questions' relationships, or all in
      *                       an array.
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function mci_event_subscriptions($EVT_ID)
     {
-        return array(
+        return [
             'list'    => $this->mci_event_list($EVT_ID),
             'groups'  => $this->mci_event_list_group($EVT_ID),
             'qfields' => $this->mci_event_list_question_fields($EVT_ID),
-        );
+        ];
     }
 
 
     /**
      * Check the MC data in the DB to see if it can be used in the MC API v3 or needs to be updated.
      *
-     * @access public
-     * @param int $EVT_ID  The ID of the Event.
-     * @param int $list_id MC List ID the Event in "subscribed" for.
+     * @param int  $EVT_ID  The ID of the Event.
+     * @param bool $list_id MC List ID the Event in "subscribed" for.
      * @return void
+     * @throws EE_Error
+     * @throws ReflectionException
      */
     public function is_db_data_api_compatible($EVT_ID, $list_id = false)
     {
@@ -1027,13 +1034,13 @@ class EE_MCI_Controller
         }
 
         // Check the data structure.
-        $event_groups = $this->mci_event_list_group($EVT_ID);
+        $event_groups  = $this->mci_event_list_group($EVT_ID);
         $old_structure = true;
         if (! empty($event_groups)) {
             if (is_array($event_groups)) {
                 // Just get the first element and see if it has the right structure.
                 $event_interest = $event_groups[0];
-                $interest = explode('-', $event_interest);
+                $interest       = explode('-', $event_interest);
                 if (isset($interest[3]) && ($interest[3] === 'true' || $interest[3] === 'false')) {
                     $old_structure = false;
                 }
@@ -1043,9 +1050,9 @@ class EE_MCI_Controller
         if ($old_structure) {
             // If we are here the data was not updated yet.
             // Clear MailChimp data on the current event and then save the updated data.
-            EEM_Event_Mailchimp_List_Group::instance()->delete(array(array('EVT_ID' => $EVT_ID)));
+            EEM_Event_Mailchimp_List_Group::instance()->delete([['EVT_ID' => $EVT_ID]]);
 
-            $list_interests = array();
+            $list_interests = [];
             // Fetch the lists/groups/interests for this event.
             $categories = $this->mci_get_users_groups($list_id);
             if (! empty($categories) && is_array($categories)) {
@@ -1063,17 +1070,19 @@ class EE_MCI_Controller
                 }
 
                 // Update the old rows.
-                $saved_interests = array();
+                $saved_interests = [];
                 foreach ($event_groups as $event_interest) {
                     $list_and_interest = explode('-', $event_interest);
                     // Double check just in case we do get one already updated field.
-                    if (isset($list_and_interest[3]) && ($list_and_interest[3] === 'true' || $list_and_interest[3] === 'false')) {
+                    if (isset($list_and_interest[3])
+                        && ($list_and_interest[3] === 'true' || $list_and_interest[3] === 'false')
+                    ) {
                         $new_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
-                            array(
+                            [
                                 'EVT_ID'                 => $EVT_ID,
                                 'AMC_mailchimp_list_id'  => $list_id,
                                 'AMC_mailchimp_group_id' => $event_interest,
-                            )
+                            ]
                         );
                         $new_list_interest->save();
                         continue;
@@ -1082,16 +1091,16 @@ class EE_MCI_Controller
                     $interest_data = array_shift($list_interests[ $interest_name ]);
                     if (! empty($interest_data) && is_array($interest_data)) {
                         // Update current row data.
-                        $list_group_id = $interest_data['id']
-                                         . '-' . $interest_data['category_id']
-                                         . '-' . base64_encode($interest_data['name'])
-                                         . '-true';
+                        $list_group_id     = $interest_data['id']
+                                             . '-' . $interest_data['category_id']
+                                             . '-' . base64_encode($interest_data['name'])
+                                             . '-true';
                         $new_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
-                            array(
+                            [
                                 'EVT_ID'                 => $EVT_ID,
                                 'AMC_mailchimp_list_id'  => $list_id,
                                 'AMC_mailchimp_group_id' => $list_group_id,
-                            )
+                            ]
                         );
                         $new_list_interest->save();
                         $saved_interests[] = $interest_data['id'];
@@ -1105,16 +1114,16 @@ class EE_MCI_Controller
                             continue;
                         }
                         // Add these as not selected.
-                        $lg_id = $mss_interest['id']
-                                 . '-' . $mss_interest['category_id']
-                                 . '-' . base64_encode($mss_interest['name'])
-                                 . '-false';
+                        $lg_id             = $mss_interest['id']
+                                             . '-' . $mss_interest['category_id']
+                                             . '-' . base64_encode($mss_interest['name'])
+                                             . '-false';
                         $new_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
-                            array(
+                            [
                                 'EVT_ID'                 => $EVT_ID,
                                 'AMC_mailchimp_list_id'  => $list_id,
                                 'AMC_mailchimp_group_id' => $lg_id,
-                            )
+                            ]
                         );
                         $new_list_interest->save();
                         $saved_interests[] = $mss_interest['id'];
@@ -1124,11 +1133,11 @@ class EE_MCI_Controller
                 // Looks like there are no interests for this list.
                 // So we should just add the Event List relation with no interests.
                 $new_list_interest = EE_Event_Mailchimp_List_Group::new_instance(
-                    array(
+                    [
                         'EVT_ID'                 => $EVT_ID,
                         'AMC_mailchimp_list_id'  => $list_id,
                         'AMC_mailchimp_group_id' => '-1',
-                    )
+                    ]
                 );
                 $new_list_interest->save();
             }
@@ -1138,13 +1147,13 @@ class EE_MCI_Controller
         // If the MC email (MERGE0) field was mapped to a different form input, remove that override.
         $mc_field_to_ee_q_map = $this->mci_event_list_question_fields($EVT_ID);
         if (array_key_exists('EMAIL', $mc_field_to_ee_q_map)) {
-            $mcqe_deleted = EEM_Question_Mailchimp_Field::instance()->delete(
-                array(
-                    array(
+            EEM_Question_Mailchimp_Field::instance()->delete(
+                [
+                    [
                         'EVT_ID'                 => $EVT_ID,
                         'QMC_mailchimp_field_id' => 'EMAIL',
-                    ),
-                )
+                    ],
+                ]
             );
         }
 
@@ -1159,25 +1168,23 @@ class EE_MCI_Controller
      * @access private
      * @param array | Exception | boolean $reply An error reply from MailChimp API.
      * @return void
+     * @throws EE_Error
      */
     private function set_error($reply)
     {
         if ($reply instanceof Exception) {
             $error['code'] = $reply->getCode();
-            $error['msg'] = $reply->getMessage();
+            $error['msg']  = $reply->getMessage();
             $error['body'] = $reply->getTraceAsString();
         } elseif (is_array($reply)) {
             $error['code'] = (isset($reply['status'])) ? $reply['status'] : 0;
-            $error['msg'] = (isset($reply['title']))
+            $error['msg']  = (isset($reply['title']))
                 ? $reply['title']
-                : __(
-                    'Unknown MailChimp Error.',
-                    'event_espresso'
-                );
+                : esc_html__('Unknown MailChimp Error.', 'event_espresso');
             $error['body'] = (isset($reply['detail'])) ? $reply['detail'] : '';
         } else {
             $error['code'] = 0;
-            $error['msg'] = __('Invalid MailChimp API Key.', 'event_espresso');
+            $error['msg']  = esc_html__('Invalid MailChimp API Key.', 'event_espresso');
             $error['body'] = '';
         }
         $this->mcapi_error = apply_filters('FHEE__EE_MCI_Controller__mci_throw_error__mcapi_error', $error);

--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -203,7 +203,7 @@ class EE_MCI_Controller
                         $this->is_db_data_api_compatible($EVT_ID, $event_list);
 
                         $need_reg_status = $reg_approved = false;
-                        $mc_config = EED_Mailchimp::get_config();
+                        $mc_config       = EED_Mailchimp::get_config();
                         if ($mc_config->api_settings->submit_to_mc_when === 'reg-step-approved') {
                             $need_reg_status = true;
                             $reg_status      = $registration->status_ID();
@@ -218,10 +218,7 @@ class EE_MCI_Controller
                             continue;
                         }
                         $att_email = $attendee->email();
-                        if (! in_array(
-                                $att_email,
-                                $registered_attendees
-                            )
+                        if (! in_array($att_email, $registered_attendees)
                             && (! $need_reg_status || $reg_approved)
                         ) {
                             $opt_in         = isset($this->_config->api_settings->skip_double_optin)
@@ -501,15 +498,14 @@ class EE_MCI_Controller
      */
     private function get_list($method, array $parameters, $key)
     {
-
         try {
             $reply = $this->MailChimp->get($method, $parameters);
         } catch (Exception $e) {
             $this->set_error($e);
             return [];
         }
-        if ($this->MailChimp->success() && isset($reply[ $key])) {
-            return (array) $reply[ $key];
+        if ($this->MailChimp->success() && isset($reply[ $key ])) {
+            return (array) $reply[ $key ];
         }
         // The list of requested items might just be empty or there might be an error response.
         if (! $this->MailChimp->success()) {
@@ -648,15 +644,15 @@ class EE_MCI_Controller
         }
 
         // Lists and Groups
-        $list_id = sanitize_text_field($_POST['ee_mailchimp_lists']);
+        $list_id          = sanitize_text_field($_POST['ee_mailchimp_lists']);
         $mailchimp_groups = array_key_exists('ee_mailchimp_groups', $_POST)
             ? $_POST['ee_mailchimp_groups']
             : [];
-        $all_interests = array_key_exists('ee_mc_list_all_interests', $_POST)
+        $all_interests    = array_key_exists('ee_mc_list_all_interests', $_POST)
             ? $_POST['ee_mc_list_all_interests']
             : [];
         if (! empty($mailchimp_groups) && ! empty($all_interests)) {
-            $group_ids     = [];
+            $group_ids = [];
             // Multidimensional array ? Straighten it up.
             foreach ($mailchimp_groups as $g_id) {
                 if (is_array($g_id)) {
@@ -713,7 +709,7 @@ class EE_MCI_Controller
                 $encoded = base64_encode($mc_question_id);
                 if (isset($_POST[ $encoded ]) && $_POST[ $encoded ] != '-1') {
                     $ev_question = $_POST[ $encoded ];
-                    $q_found = false;
+                    $q_found     = false;
                     // Update already present Q fields.
                     foreach ($qf_exists as $question_field) {
                         $mc_field = $question_field instanceof EE_Question_Mailchimp_Field
@@ -724,9 +720,9 @@ class EE_MCI_Controller
                                 ['QST_ID' => $ev_question],
                                 [
                                     [
-                                        'EVT_ID' => $event_id,
-                                        'QMC_mailchimp_field_id' => $mc_question_id
-                                    ]
+                                        'EVT_ID'                 => $event_id,
+                                        'QMC_mailchimp_field_id' => $mc_question_id,
+                                    ],
                                 ]
                             );
                             $q_found = true;

--- a/includes/MailChimp.class.php
+++ b/includes/MailChimp.class.php
@@ -2,52 +2,62 @@
 
 namespace EEA_MC;
 
+use Exception;
+
 /**
  * Super-simple, minimum abstraction MailChimp API v3 wrapper
  * MailChimp API v3: http://developer.mailchimp.com
  * This wrapper: https://github.com/drewm/mailchimp-api
  *
- * @author Drew McLellan <drew.mclellan@gmail.com>
+ * @author  Drew McLellan <drew.mclellan@gmail.com>
  * @version 2.2
  */
 class MailChimp
 {
     private $api_key;
+
     private $api_endpoint = 'https://<dc>.api.mailchimp.com/3.0';
 
     /*  SSL Verification
         Read before disabling:
         http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
     */
-    public $verify_ssl = false;
+    public  $verify_ssl         = false;
 
     private $request_successful = false;
+
     private $last_error         = '';
-    private $last_response      = array();
-    private $last_request       = array();
+
+    private $last_response      = [];
+
+    private $last_request       = [];
+
 
     /**
      * Create a new instance
+     *
      * @param string $api_key Your MailChimp API key
-     * @throws \Exception
+     * @throws Exception
      */
     public function __construct($api_key)
     {
-        $this->api_key = $api_key;
+        $this->api_key    = $api_key;
         $this->verify_ssl = apply_filters('FHEE__MailChimp__construct__verify_ssl', $this->verify_ssl);
 
         if (strpos($this->api_key, '-') === false) {
-            throw new \Exception("Invalid MailChimp API key `{$api_key}` supplied.");
+            throw new Exception("Invalid MailChimp API key `{$api_key}` supplied.");
         }
 
         list(, $data_center) = explode('-', $this->api_key);
-        $this->api_endpoint  = str_replace('<dc>', $data_center, $this->api_endpoint);
+        $this->api_endpoint = str_replace('<dc>', $data_center, $this->api_endpoint);
 
-        $this->last_response = array('headers' => null, 'body' => null);
+        $this->last_response = ['headers' => null, 'body' => null];
     }
+
 
     /**
      * Create a new instance of a Batch request. Optionally with the ID of an existing batch.
+     *
      * @param string $batch_id Optional ID of an existing batch, if you need to check its status for example.
      * @return Batch            New Batch object.
      */
@@ -56,9 +66,11 @@ class MailChimp
         return new Batch($this, $batch_id);
     }
 
+
     /**
      * Convert an email address into a 'subscriber hash' for identifying the subscriber in a method URL
-     * @param   string $email The subscriber's email address
+     *
+     * @param string $email The subscriber's email address
      * @return  string          Hashed version of the input
      */
     public function subscriberHash($email)
@@ -66,8 +78,10 @@ class MailChimp
         return md5(strtolower($email));
     }
 
+
     /**
      * Was the last request successful?
+     *
      * @return bool  True for success, false for failure
      */
     public function success()
@@ -75,18 +89,22 @@ class MailChimp
         return $this->request_successful;
     }
 
+
     /**
      * Get the last error returned by either the network transport, or by the API.
      * If something didn't work, this should contain the string describing the problem.
+     *
      * @return  array|false  describing the error
      */
     public function getLastError()
     {
-        return $this->last_error ?: false;
+        return $this->last_error ? : false;
     }
+
 
     /**
      * Get an array containing the HTTP headers and the body of the API response.
+     *
      * @return array  Assoc array with keys 'headers' and 'body'
      */
     public function getLastResponse()
@@ -94,8 +112,10 @@ class MailChimp
         return $this->last_response;
     }
 
+
     /**
      * Get an array containing the HTTP headers and the body of the API request.
+     *
      * @return array  Assoc array
      */
     public function getLastRequest()
@@ -103,104 +123,129 @@ class MailChimp
         return $this->last_request;
     }
 
+
     /**
      * Make an HTTP DELETE request - for deleting data
-     * @param   string $method URL of the API request method
-     * @param   array $args Assoc array of arguments (if any)
-     * @param   int $timeout Timeout limit for request in seconds
+     *
+     * @param string $method  URL of the API request method
+     * @param array  $args    Assoc array of arguments (if any)
+     * @param int    $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
+     * @throws Exception
      */
-    public function delete($method, $args = array(), $timeout = 10)
+    public function delete($method, $args = [], $timeout = 10)
     {
         return $this->makeRequest('delete', $method, $args, $timeout);
     }
 
+
     /**
      * Make an HTTP GET request - for retrieving data
-     * @param   string $method URL of the API request method
-     * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     *
+     * @param string $method  URL of the API request method
+     * @param array  $args    Assoc array of arguments (usually your data)
+     * @param int    $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
+     * @throws Exception
      */
-    public function get($method, $args = array(), $timeout = 10)
+    public function get($method, $args = [], $timeout = 10)
     {
         return $this->makeRequest('get', $method, $args, $timeout);
     }
 
+
     /**
      * Make an HTTP PATCH request - for performing partial updates
-     * @param   string $method URL of the API request method
-     * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     *
+     * @param string $method  URL of the API request method
+     * @param array  $args    Assoc array of arguments (usually your data)
+     * @param int    $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
+     * @throws Exception
      */
-    public function patch($method, $args = array(), $timeout = 10)
+    public function patch($method, $args = [], $timeout = 10)
     {
         return $this->makeRequest('patch', $method, $args, $timeout);
     }
 
+
     /**
      * Make an HTTP POST request - for creating and updating items
-     * @param   string $method URL of the API request method
-     * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     *
+     * @param string $method  URL of the API request method
+     * @param array  $args    Assoc array of arguments (usually your data)
+     * @param int    $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
+     * @throws Exception
      */
-    public function post($method, $args = array(), $timeout = 10)
+    public function post($method, $args = [], $timeout = 10)
     {
         return $this->makeRequest('post', $method, $args, $timeout);
     }
 
+
     /**
      * Make an HTTP PUT request - for creating new items
-     * @param   string $method URL of the API request method
-     * @param   array $args Assoc array of arguments (usually your data)
-     * @param   int $timeout Timeout limit for request in seconds
+     *
+     * @param string $method  URL of the API request method
+     * @param array  $args    Assoc array of arguments (usually your data)
+     * @param int    $timeout Timeout limit for request in seconds
      * @return  array|false   Assoc array of API response, decoded from JSON
+     * @throws Exception
      */
-    public function put($method, $args = array(), $timeout = 10)
+    public function put($method, $args = [], $timeout = 10)
     {
         return $this->makeRequest('put', $method, $args, $timeout);
     }
 
+
     /**
      * Performs the underlying HTTP request. Not very exciting.
-     * @param  string $http_verb The HTTP verb to use: get, post, put, patch, delete
-     * @param  string $method The API method to be called
-     * @param  array $args Assoc array of parameters to be passed
-     * @param int $timeout
+     *
+     * @param string $http_verb The HTTP verb to use: get, post, put, patch, delete
+     * @param string $method    The API method to be called
+     * @param array  $args      Assoc array of parameters to be passed
+     * @param int    $timeout
      * @return array|false Assoc array of decoded result
-     * @throws \Exception
+     * @throws Exception
      */
-    private function makeRequest($http_verb, $method, $args = array(), $timeout = 10)
+    private function makeRequest($http_verb, $method, $args = [], $timeout = 10)
     {
-        if (!function_exists('curl_init') || !function_exists('curl_setopt')) {
-            throw new \Exception("cURL support is required, but can't be found.");
+        if (! function_exists('curl_init') || ! function_exists('curl_setopt')) {
+            throw new Exception("cURL support is required, but can't be found.");
         }
 
         $url = $this->api_endpoint . '/' . $method;
 
         $this->last_error         = '';
         $this->request_successful = false;
-        $response                 = array('headers' => null, 'body' => null);
+        $response                 = ['headers' => null, 'body' => null];
         $this->last_response      = $response;
 
-        $this->last_request = array(
+        $this->last_request = [
             'method'  => $http_verb,
             'path'    => $method,
             'url'     => $url,
             'body'    => '',
             'timeout' => $timeout,
-        );
+        ];
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-            'Accept: application/vnd.api+json',
-            'Content-Type: application/vnd.api+json',
-            'Authorization: apikey ' . $this->api_key
-        ));
-        curl_setopt($ch, CURLOPT_USERAGENT, 'Event Espresso Integration/MailChimp-API/3.0 (https://eventespresso.com/forum/mailchimp-integration/)');
+        curl_setopt(
+            $ch,
+            CURLOPT_HTTPHEADER,
+            [
+                'Accept: application/vnd.api+json',
+                'Content-Type: application/vnd.api+json',
+                'Authorization: apikey ' . $this->api_key,
+            ]
+        );
+        curl_setopt(
+            $ch,
+            CURLOPT_USERAGENT,
+            'Event Espresso Integration/MailChimp-API/3.0 (https://eventespresso.com/forum/mailchimp-integration/)'
+        );
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verify_ssl);
@@ -254,20 +299,24 @@ class MailChimp
         return $formattedResponse;
     }
 
+
     /**
      * Encode the data and attach it to the request
-     * @param   resource $ch cURL session handle, used by reference
-     * @param   array $data Assoc array of data to attach
+     *
+     * @param resource $ch   cURL session handle, used by reference
+     * @param array    $data Assoc array of data to attach
      */
     private function attachRequestPayload(&$ch, $data)
     {
-        $encoded = json_encode($data);
+        $encoded                    = json_encode($data);
         $this->last_request['body'] = $encoded;
         curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded);
     }
 
+
     /**
      * Decode the response and format any error messages for debugging
+     *
      * @param array $response The response from the curl request
      * @return array|false    The JSON decoded into an array
      */
@@ -275,16 +324,18 @@ class MailChimp
     {
         $this->last_response = $response;
 
-        if (!empty($response['body'])) {
+        if (! empty($response['body'])) {
             return json_decode($response['body'], true);
         }
 
         return false;
     }
 
+
     /**
      * Check if the response was successful or a failure. If it failed, store the error.
-     * @param array $response The response from the curl request
+     *
+     * @param array       $response          The response from the curl request
      * @param array|false $formattedResponse The response body payload from the curl request
      * @return bool     If the request was successful
      */
@@ -306,19 +357,21 @@ class MailChimp
         return false;
     }
 
+
     /**
      * Find the HTTP status code from the headers or API response body
-     * @param array $response The response from the curl request
+     *
+     * @param array       $response          The response from the curl request
      * @param array|false $formattedResponse The response body payload from the curl request
      * @return int  HTTP status code
      */
     private function findHTTPStatus($response, $formattedResponse)
     {
-        if (!empty($response['headers']) && isset($response['headers']['http_code'])) {
+        if (! empty($response['headers']) && isset($response['headers']['http_code'])) {
             return (int) $response['headers']['http_code'];
         }
 
-        if (!empty($response['body']) && isset($formattedResponse['status'])) {
+        if (! empty($response['body']) && isset($formattedResponse['status'])) {
             return (int) $formattedResponse['status'];
         }
 

--- a/includes/MailChimp.class.php
+++ b/includes/MailChimp.class.php
@@ -14,23 +14,44 @@ use Exception;
  */
 class MailChimp
 {
-    private $api_key;
-
+    /**
+     * @var string
+     */
     private $api_endpoint = 'https://<dc>.api.mailchimp.com/3.0';
 
-    /*  SSL Verification
-        Read before disabling:
-        http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
-    */
-    public  $verify_ssl         = false;
+    /**
+     * @var string
+     */
+    private $api_key;
 
+    /**
+     * @var string
+     */
+    private $last_error = '';
+
+    /**
+     * @var array
+     */
+    private $last_response = [];
+
+    /**
+     * @var array
+     */
+    private $last_request = [];
+
+    /**
+     * @var bool
+     */
     private $request_successful = false;
 
-    private $last_error         = '';
-
-    private $last_response      = [];
-
-    private $last_request       = [];
+    /**
+     * SSL Verification
+     * Read before disabling:
+     * http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/
+     *
+     * @var bool
+     */
+    public $verify_ssl = false;
 
 
     /**

--- a/includes/forms/EE_MC_Merge_Fields_Form.form.php
+++ b/includes/forms/EE_MC_Merge_Fields_Form.form.php
@@ -7,60 +7,54 @@
  * @package         Event Espresso
  * @subpackage      ee4-mailchimp
  * @since           2.4.0.rc.000
- * ------------------------------------------------------------------------
  */
 class EE_MC_Merge_Fields_Form extends EE_Form_Section_Proper
 {
 
     /**
-     * @access protected
      * @var object $_mc_controller
      */
     protected $_mc_controller = null;
 
     /**
-     * @access protected
      * @var string $_list_id
      */
-    protected $_list_id = null;
+    protected $_list_id = '';
 
     /**
-     * @access protected
      * @var string $_event_id
      */
-    protected $_event_id = null;
+    protected $_event_id = '';
 
     /**
-     * @access protected
      * @var array $_list_fields
      */
-    protected $_list_fields = null;
+    protected $_list_fields = [];
 
     /**
-     * @access protected
      * @var array $_selected_fields
      */
-    protected $_selected_fields = null;
+    protected $_selected_fields = [];
 
     /**
-     * @access protected
      * @var array $_evt_questions
      */
-    protected $_evt_questions = null;
+    protected $_evt_questions = [];
 
 
     /**
      * Class constructor
      *
      * @param EE_MCI_Controller $mc_controller
+     * @param int               $event_id
      * @param string            $list_id
-     * @return EE_Form_Section_Proper
+     * @throws EE_Error
      */
     public function __construct(EE_MCI_Controller $mc_controller, $event_id, $list_id)
     {
         $this->_mc_controller = $mc_controller;
-        $this->_list_id = $list_id;
-        $this->_event_id = $event_id;
+        $this->_event_id      = $event_id;
+        $this->_list_id       = $list_id;
 
         $options = $this->_template_setup();
 
@@ -71,23 +65,22 @@ class EE_MC_Merge_Fields_Form extends EE_Form_Section_Proper
     /**
      * Prepare the form options.
      *
-     * @access public
      * @return array  section options.
      */
     protected function _template_setup()
     {
-        $options = array(
+        $options = [
             'html_id'         => 'espresso-mci-list-merge-fields',
             'html_class'      => 'espresso_mci_merge_fields_tb',
             'layout_strategy' => new EE_Two_Column_Layout(),
-        );
+        ];
         if ($this->_list_id && $this->_list_id !== '-1') {
             // Get MC list fields.
-            $list_fields = $this->_mc_controller->mci_get_list_merge_vars($this->_list_id);
+            $list_fields     = $this->_mc_controller->mci_get_list_merge_vars($this->_list_id);
             $selected_fields = $this->_mc_controller->mci_event_list_question_fields($this->_event_id);
-            $evt_questions = $this->_mc_controller->mci_get_event_all_questions($this->_event_id);
+            $evt_questions   = $this->_mc_controller->mci_get_event_all_questions($this->_event_id);
 
-            $m_fields = array();
+            $m_fields = [];
             if (! empty($list_fields)) {
                 $m_fields = $this->_merge_fields($list_fields, $selected_fields, $evt_questions);
             } elseif ($_GET['action'] === 'create_new') {
@@ -96,10 +89,7 @@ class EE_MC_Merge_Fields_Form extends EE_Form_Section_Proper
             } else {
                 $m_fields['no_lists'] = new EE_Form_Section_HTML(
                     EEH_HTML::p(
-                        esc_html__(
-                            'Sorry, no merge fields found!',
-                            'event_espresso'
-                        ),
+                        esc_html__('Sorry, no merge fields found!', 'event_espresso'),
                         'no-lists-found-notice',
                         'important-notice'
                     )
@@ -118,75 +108,78 @@ class EE_MC_Merge_Fields_Form extends EE_Form_Section_Proper
     /**
      * List all merge fields.
      *
-     * @access public
      * @param array $list_fields
      * @param array $selected_fields
      * @param array $evt_questions
      * @return array  List of merge fields pairs.
      */
-    protected function _merge_fields($list_fields, $selected_fields, $evt_questions)
+    protected function _merge_fields(array $list_fields, array $selected_fields, array $evt_questions)
     {
-        $subsactions = $hide_fields = array();
+        $subs_actions = $hide_fields = [];
 
         // Add Table heading.
-        $subsactions['mc_ql_tbl'] = new EE_Form_Section_HTML(
+        $subs_actions['mc_ql_tbl'] = new EE_Form_Section_HTML(
             EEH_HTML::no_row(EEH_HTML::br()) .
             EEH_HTML::tr(
-                EEH_HTML::th(esc_html__('Mailchimp Fields', 'event_espresso')) .
+                EEH_HTML::th(esc_html__('MailChimp Fields', 'event_espresso')) .
                 EEH_HTML::th(esc_html__('Event Espresso Questions', 'event_espresso'))
             )
         );
 
         foreach ($list_fields as $l_field) {
-            $selected = '-1';
-            $fields_list = array();
+            $selected    = '-1';
+            $fields_list = [];
 
             foreach ($evt_questions as $q_field) {
                 $fields_list[ $q_field['QST_ID'] ] = $q_field['QST_name'];
 
                 // Default to main fields if exist.
                 if ((isset($l_field['tag'], $selected_fields[ $l_field['tag'] ])
-                     && ($selected_fields[ $l_field['tag'] ] == $q_field['QST_ID'] || $selected_fields[ $l_field['tag'] ] == $q_field['QST_system']))
-                    || (($q_field['QST_system'] == 'email' || $q_field['QST_ID'] == 3) && $l_field['tag'] == 'EMAIL' && ! array_key_exists(
-                        'EMAIL',
-                        $selected_fields
-                    ))
-                    || (($q_field['QST_system'] == 'lname' || $q_field['QST_ID'] == 2) && $l_field['tag'] == 'LNAME' && ! array_key_exists(
-                        'LNAME',
-                        $selected_fields
-                    ))
-                    || (($q_field['QST_system'] == 'fname' || $q_field['QST_ID'] == 1) && $l_field['tag'] == 'FNAME' && ! array_key_exists(
-                        'FNAME',
-                        $selected_fields
-                    ))
+                     && ($selected_fields[ $l_field['tag'] ] == $q_field['QST_ID']
+                         || $selected_fields[ $l_field['tag'] ] == $q_field['QST_system']))
+                    || (($q_field['QST_system'] == 'email' || $q_field['QST_ID'] == 3) && $l_field['tag'] == 'EMAIL'
+                        && ! array_key_exists(
+                            'EMAIL',
+                            $selected_fields
+                        ))
+                    || (($q_field['QST_system'] == 'lname' || $q_field['QST_ID'] == 2) && $l_field['tag'] == 'LNAME'
+                        && ! array_key_exists(
+                            'LNAME',
+                            $selected_fields
+                        ))
+                    || (($q_field['QST_system'] == 'fname' || $q_field['QST_ID'] == 1) && $l_field['tag'] == 'FNAME'
+                        && ! array_key_exists(
+                            'FNAME',
+                            $selected_fields
+                        ))
                 ) {
                     $selected = $q_field['QST_ID'];
                 }
             }
 
             // Add a default value.
-            $fields_list['-1'] = esc_html__('none', 'event_espresso');
-            $subsactions[ $l_field['tag'] ] = new EE_Select_Input(
+            $fields_list['-1']              = esc_html__('none', 'event_espresso');
+            $subs_actions[ $l_field['tag'] ] = new EE_Select_Input(
                 $fields_list,
-                array(
+                [
                     'default'         => $selected,
                     'html_label_text' => $l_field['required'] ? $l_field['name'] . '*' : $l_field['name'],
                     'html_id'         => 'event-question-' . base64_encode($l_field['name']),
                     'html_name'       => base64_encode($l_field['tag']),
                     'html_class'      => 'ee_event_fields_selects',
-                )
+                ]
             );
 
             // Need to pass all fields that are available.
-            $subsactions[ 'hdn-qf-' . $l_field['tag'] ] = new EE_Hidden_Input(
-                array(
+            $subs_actions[ 'hdn-qf-' . $l_field['tag'] ] = new EE_Hidden_Input(
+                [
                     'html_name' => 'ee_mailchimp_qfields[]',
                     'html_id'   => 'ee-mc-qf-' . $l_field['tag'],
                     'default'   => $l_field['tag'],
-                )
+                ]
             );
         }
 
-        return $subsactions;
+        return $subs_actions;
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,7 @@
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>EE_Mailchimp_Config.php</exclude-pattern>
+        <exclude-pattern>EE_Mailchimp_Config_Api_Settings.php</exclude-pattern>
         <exclude-pattern>Mailchimp_Admin_Page_Init.core.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/tests/testcases/EE_MailChimp_Tests.php
+++ b/tests/testcases/EE_MailChimp_Tests.php
@@ -11,55 +11,62 @@
 /**
  * Test class for EE_MailChimp
  */
-class EE_MailChimp_Tests extends EE_UnitTestCase {
+class EE_MailChimp_Tests extends EE_UnitTestCase
+{
 
     /**
      * Tests the loading of the main MC file.
      */
-    function test_loading_MailChimp() {
-        $this->assertEquals( has_action('AHEE__EE_System__load_espresso_addons', 'load_ee4_espresso_mailchimp_class'), 11 );
-        $this->assertTrue( class_exists( 'EE_MailChimp' ) );
+    function test_loading_MailChimp()
+    {
+        $this->assertEquals(
+            has_action('AHEE__EE_System__load_espresso_addons', 'load_ee4_espresso_mailchimp_class'),
+            11
+        );
+        $this->assertTrue(class_exists('EE_MailChimp'));
     }
+
 
     /**
-     * Tests the loading of all of the MC add-on files throught EE Addon API.
-     * 
+     * Tests the loading of all of the MC add-on files throughout EE Addon API.
+     *
      */
-    function test_all_the_autoloader_paths_loaded() {
+    function test_all_the_autoloader_paths_loaded()
+    {
         // autoloader_paths
-        $this->assertTrue( class_exists( 'EE_MCI_Controller' ) );
+        $this->assertTrue(class_exists('EE_MCI_Controller'));
     }
 
-    function test_all_the_module_paths_loaded() {
+
+    function test_all_the_module_paths_loaded()
+    {
         // module_paths
-        $this->assertTrue( class_exists( 'EED_Mailchimp' ) );
+        $this->assertTrue(class_exists('EED_Mailchimp'));
     }
 
-    function test_all_the_config_class_paths_loaded() {
+
+    function test_all_the_config_class_paths_loaded()
+    {
         // config_class
-        $this->assertTrue( class_exists( 'EE_Mailchimp_Config' ) );
+        $this->assertTrue(class_exists('EE_Mailchimp_Config'));
     }
+
 
     /**
      * Check if MailChimp API loaded.
      */
-    function test_if_the_mailchimp_api_loaded() {
+    function test_if_the_mailchimp_api_loaded()
+    {
         // MailChimp API.
-        $this->assertTrue( class_exists( '\EEA_MC\MailChimp' ) );
+        $this->assertTrue(class_exists('\EEA_MC\MailChimp'));
     }
 
-    function test_all_the_dms_paths_loaded() {
+
+    function test_all_the_dms_paths_loaded()
+    {
         // dms_paths
-        $this->assertTrue( class_exists( 'EE_DMS_MailChimp_2_0_0' ) );
-        $this->assertTrue( class_exists( 'EE_DMS_2_0_0_mc_list_group' ) );
-        $this->assertTrue( class_exists( 'EE_DMS_2_0_0_mc_options' ) );
-    }
-
-    /**
-     * Tests the return value of name() method (that had to override parent).
-     */
-    function test_mc_returns_correvt_addon_name() {
-        $mc = new EE_MailChimp();
-        $this->assertEquals( 'MailChimp', $mc->name() );
+        $this->assertTrue(class_exists('EE_DMS_MailChimp_2_0_0'));
+        $this->assertTrue(class_exists('EE_DMS_2_0_0_mc_list_group'));
+        $this->assertTrue(class_exists('EE_DMS_2_0_0_mc_options'));
     }
 }


### PR DESCRIPTION
plz see: https://github.com/eventespresso/event-espresso-core/issues/3259

This PR: 

- extracts `EE_Mailchimp_Config_Api_Settings` from `EE_Mailchimp_Config.php` into its own file

- removed `EE_MailChimp::name()` because it returned the exact same value as the parent class method but caused the error seen in 3259 since it lacked the type safety.

- extracted some duplicated logic in `EE_MCI_Controller` into a new private method

- added sanitization to `$_POST` data that was untreated !!!!!!!!!!!!!

- a bunch of code cleanup and formatting, including:

	- fixing i18n strings ie: changing `__()` to `esc_html__()`, etc
	- auto formatting via my IDE
	- fixing/adding phpdoc blocks
	- fixing typos (it's MailChimp dangit)

I will try to add comments to any changes that are more substantial than just code cleanup and/or formatting so that the review is not as painful