### PR TITLE
Don't use sanitize_text_field so both the 'selected' group and the list of groups are sanitized using the same method.

### DIFF
--- a/includes/EE_MCI_Controller.class.php
+++ b/includes/EE_MCI_Controller.class.php
@@ -665,7 +665,7 @@ class EE_MCI_Controller
             }
             // We need to save the list of all interests for the current MC List.
             foreach ($all_interests as $interest) {
-                $interest = sanitize_key($interest);
+                $interest = sanitize_text_field($interest);
                 // Mark what lists were selected and not.
                 if (in_array($interest, $group_ids)) {
                     $interest .= '-true';


### PR DESCRIPTION
I couldn't select MailChimp groups locally, but it worked on a live site with the same list.

Turns out there's a recent change to use sanitize_key() on the select groups, however, my groups (and possibly all) have `==` at the end (which is removed by sanitize_key() ):

`80fffxxxxx-fda5cxxxxx-VHN0MQ==`

So then the 'selected' groups where being compared with the MailChimp groups array but none would match as the originals had the full string.

This change swaps out the usage of sanitize_key for sanitize_text_field (which is what the Mailchimp groups array uses).


## How has this been tested
Load MailChimp with the master branch.

On an event select a list with groups and then try to select at least one of those groups.

The page will reload but nothing will be selected.

Switch to this branch and retest.
## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
